### PR TITLE
ADDED: Template file for creating issue and pull request for Github

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: troublediehard
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Current Behavior**
+What is the current behavior?
+
+**Steps to Reproduce**
+Please provide detailed steps for reproducing the issue.
+1. Navigate to...
+2. Press on...
+3. Scroll to...
+4. See error...
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Smartphone (please complete the following information):**
+ - Magento Version: [e.g. 2.1.0]
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,0 +1,12 @@
+---
+name: Custom Issue Template
+about: Tell us something related to the project or general discussion
+title: ''
+labels: question
+assignees: troublediehard
+
+---
+
+**Are there certain things to report that are not a bug or feature?**
+Please tell us as exactly as possible about your request, thanks.
+We will reply as soon as possible.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature Request
+about: Suggest an idea for this mobile app
+title: ''
+labels: enhancement
+assignees: alexakasanjeev
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+**What does this implement/fix? Explain your changes.**
+Please explain your changes in addition to your commit messages.
+
+**Does this close any currently open issues?**
+If yes, please mention, else ignore.
+
+**Screenshots**
+If applicable, add screenshots of end result.
+
+**Any other comments?**
+
+**Where has this been tested?**
+---------------------------
+ - Magento Version: [e.g. 2.1.0]
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Version [e.g. 22]


### PR DESCRIPTION
**What does this implement/fix? Explain your changes.**
This pull request add new template files to create issue and pull request. When user will click on create new issue, he will be shown 3 possible template to choose from. Also for pull request, the template will be same as this current pull request look like.

**Does this close any currently open issues?**
No

**Screenshots**
[Screenshot 1](https://imgur.com/vFkCjQk)
[Screenshot 2](https://imgur.com/Kt1FhBi)

**Any other comments?**
You can go to https://github.com/alexakasanjeev/magento_react_native and create new issue or pull request to see it in action.