### PR TITLE
feat: Show error message if magento failed to initialize

### DIFF
--- a/src/actions/RestActions.js
+++ b/src/actions/RestActions.js
@@ -4,6 +4,7 @@ import { magento } from '../magento';
 import { magentoOptions } from '../config/magento';
 import {
   MAGENTO_INIT,
+  MAGENTO_INIT_ERROR,
   MAGENTO_GET_CATEGORY_TREE,
   MAGENTO_CURRENT_CATEGORY,
   MAGENTO_GET_CATEGORY_PRODUCTS,
@@ -67,6 +68,7 @@ export const initMagento = () => {
       magento.setCustomerToken(customerToken);
     } catch (error) {
       console.log(error);
+      dispatch({ type: MAGENTO_INIT_ERROR, payload: { errorMessage: error } });
     }
   };
 };
@@ -573,15 +575,11 @@ export const placeGuestCartOrder = (cartId, payment) => {
       } else {
         data = await magento.guest.placeGuestCartOrder(cartId, payment);
       }
-      if (!data.message) {
-        dispatch({ type: MAGENTO_PLACE_GUEST_CART_ORDER, payload: data });
-      } else {
-        const message = magento.getErrorMessageForResponce(data);
-        dispatch({ type: MAGENTO_ERROR_MESSAGE_CART_ORDER, payload: message });
-      }
+      dispatch({ type: MAGENTO_PLACE_GUEST_CART_ORDER, payload: data });
       dispatch({ type: UI_CHECKOUT_CUSTOMER_NEXT_LOADING, payload: false });
     } catch (error) {
       console.log(error);
+      dispatch({ type: MAGENTO_ERROR_MESSAGE_CART_ORDER, payload: error });
     }
   };
 };

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -1,4 +1,5 @@
 export const MAGENTO_INIT = 'magento_init';
+export const MAGENTO_INIT_ERROR = 'magento_init_error';
 export const MAGENTO_STORE_CONFIG = 'magento_store_config';
 export const MAGENTO_GET_COUNTRIES = 'magento_get_countries';
 

--- a/src/components/home/HomeScreen.js
+++ b/src/components/home/HomeScreen.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { ScrollView, TouchableWithoutFeedback, StyleSheet, RefreshControl } from 'react-native';
+import { ScrollView, View, TouchableWithoutFeedback, Text, StyleSheet, RefreshControl } from 'react-native';
 import { connect } from 'react-redux';
 import _ from 'lodash';
 import { MaterialHeaderButtons, Item } from '../common';
@@ -74,6 +74,14 @@ class HomeScreen extends Component {
   }
 
   render() {
+    if (this.props.errorMessage) {
+      return (
+        <View style={styles.errorContainer}>
+          <Text>{this.props.errorMessage}</Text>
+        </View>
+      );
+    }
+
     return (
       <ScrollView
         style={styles.container}
@@ -104,12 +112,18 @@ const styles = StyleSheet.create({
     alignSelf: 'center',
     width: Sizes.WINDOW_WIDTH * 0.9,
     marginBottom: 3,
+  },
+  errorContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
   }
 });
 
 const mapStateToProps = state => {
   const { refreshing } = state.home;
-  return { ...state.home, refreshing };
+  const { errorMessage } = state.magento;
+  return { ...state.home, refreshing, errorMessage };
 };
 
 export default connect(mapStateToProps, { getHomeData, setCurrentProduct })(HomeScreen);

--- a/src/reducers/MagentoReducer.js
+++ b/src/reducers/MagentoReducer.js
@@ -1,6 +1,6 @@
 import { REHYDRATE } from 'redux-persist/es/constants';
 import {
-  MAGENTO_GET_COUNTRIES, MAGENTO_INIT, MAGENTO_STORE_CONFIG,
+  MAGENTO_GET_COUNTRIES, MAGENTO_INIT, MAGENTO_INIT_ERROR, MAGENTO_STORE_CONFIG,
 } from '../actions/types';
 import { magento } from '../magento';
 
@@ -32,6 +32,8 @@ export default (state = INITIAL_STATE, action) => {
     }
     case MAGENTO_INIT:
       return { ...state, magento: action.payload };
+    case MAGENTO_INIT_ERROR:
+      return { ...state, errorMessage: action.payload.errorMessage };
     default:
       return state;
   }


### PR DESCRIPTION
**What does this implement/fix? Explain your changes.**
1. Removed redundant admin login credentials from `magento/index.js` file
2. Modified `send` method in `magento/index.js` file to handle 401 http error
3. Showed error message in `HomeScreen.js` if magento failed to initialize

**Does this close any currently open issues?**
#59

**Screenshots**
![Screenshot_1562181049](https://user-images.githubusercontent.com/13250741/60619590-a824a400-9df6-11e9-89ee-042627b6e0ef.png)

**Any other comments?**
To replicate, magento init failed,
1. Enter a wrong integration token in `magento.js` file
2. Install a fresh copy of magento-react-native on phone
3. See error on HomeScreen.js

To replicate, no network error
1. Turn off the internet
2. Install a fresh copy of magento-react-native on phone
3. See error on HomeScreen.js

**Where has this been tested?**
---------------------------
 - Magento Version: [e.g. 2.1.0]
 - Device: [Android Emulator]
 - OS: [Android Pie]
 - Version [API 28]
