### PR TITLE
feat: Remove unnecessary Promise use

### DIFF
--- a/src/actions/CustomerAuthActions.js
+++ b/src/actions/CustomerAuthActions.js
@@ -48,6 +48,8 @@ export const auth = (username, password) => {
     try {
       dispatch({ type: MAGENTO_AUTH_LOADING, payload: true });
       const response = await magento.guest.auth(username, password);
+      console.log('token');
+      magento.setCustomerToken(response);
       if (response.message) {
         authFail(dispatch, response.message);
       } else {

--- a/src/actions/RestActions.js
+++ b/src/actions/RestActions.js
@@ -59,7 +59,7 @@ export const initMagento = () => {
 
   return async dispatch => {
     try {
-      await magento.init();
+      magento.init();
       dispatch({ type: MAGENTO_INIT, payload: magento });
       const storeConfig = await magento.admin.getStoreConfig();
       dispatch({ type: MAGENTO_STORE_CONFIG, payload: storeConfig });
@@ -78,7 +78,8 @@ export const getHomeData = (refreshing) => {
     }
 
     try {
-      await magento.admin.getStoreConfig();
+      const storeConfig = await magento.admin.getStoreConfig();
+      magento.setStoreConfig(storeConfig[0]);
       const value = await magento.getHomeData();
       console.log('home', value);
       const payload = JSON.parse(value.content.replace(/<\/?[^>]+(>|$)/g, ''));
@@ -414,6 +415,7 @@ export const getOrdersForCustomer = (customerId, refreshing) => {
 
     try {
       const data = await magento.admin.getOrderList(customerId);
+      console.log('getOrderList response:', data);
       const orders = data.items.map(order => {
         const items = order.items;
         const simpleItems = items.filter(i => i.product_type === 'simple');

--- a/src/magento/index.js
+++ b/src/magento/index.js
@@ -34,38 +34,11 @@ class Magento {
   }
 
   init() {
-    return new Promise((resolve, reject) => {
-      if (this.configuration.authentication.integration.access_token) {
-        this.access_token = this.configuration.authentication.integration.access_token;
-        resolve(this);
-      } else if (this.configuration.authentication.login) {
-        const {
-          username,
-          password,
-          type
-        } = this.configuration.authentication.login;
-        if (username) {
-          let path;
-          if (type === 'admin') {
-            path = '/V1/integration/admin/token';
-          } else {
-            path = '/V1/integration/customer/token';
-          }
-
-          this.post(path, { username, password })
-            .then(token => {
-              // debugger;
-              console.log('token');
-              this.access_token = token;
-              resolve(this);
-            })
-            .catch(e => {
-              console.log(e);
-              reject(e);
-            });
-        }
-      }
-    });
+    if (this.configuration.authentication.integration.access_token) {
+      this.access_token = this.configuration.authentication.integration.access_token;
+      return;
+    } 
+    throw new Error('Need Integration Token!');
   }
 
   post(path, params, type = ADMIN_TYPE) {

--- a/src/magento/lib/admin/index.js
+++ b/src/magento/lib/admin/index.js
@@ -29,108 +29,28 @@ const getSortDirection = (sortOrder) => {
 
 export default magento => {
   return {
-    getStoreConfig: () => {
-      return new Promise((resolve, reject) => {
-        const path = '/V1/store/storeConfigs';
+    getStoreConfig: () => magento.get('/V1/store/storeConfigs', undefined, undefined, ADMIN_TYPE),
 
-        magento
-          .get(path, undefined, undefined, ADMIN_TYPE)
-          .then(data => {
-            resolve(data);
-            magento.setStoreConfig(data[0]);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
+    updateCustomerData: (id, customer) => magento.put(`/V1/customers/${id}`, customer, undefined, ADMIN_TYPE),
 
-    updateCustomerData: (id, customer) => {
-      // POST /V1/carts/mine/billing-address
-      return new Promise((resolve, reject) => {
-        const path = `/V1/customers/${id}`;
+    getCategoriesTree: () => magento.get('/V1/categories', undefined, undefined, ADMIN_TYPE),
 
-        magento
-            .put(path, customer, undefined, ADMIN_TYPE)
-            .then(data => {
-              resolve(data);
-            })
-            .catch(e => {
-              console.log(e);
-              reject(e);
-            });
-      });
-    },
+    getCategory: id => magento.get(`/V1/categories/${id}`, undefined, undefined, ADMIN_TYPE),
 
-    getCategoriesTree: () => {
-      return new Promise((resolve, reject) => {
-        const path = '/V1/categories';
-        magento
-          .get(path, undefined, undefined, ADMIN_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
-
-    getCategory: id => {
-      return new Promise((resolve, reject) => {
-        const path = `/V1/categories/${id}`;
-        magento
-          .get(path, undefined, undefined, ADMIN_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
-
-    getCategoryAttributes: attributeCode => {
-      // GET /V1/categories/attributes/:attributeCode
-      return new Promise((resolve, reject) => {
-        const path = `/V1/categories/attributes/${attributeCode}`;
-        magento
-          .get(path, undefined, undefined, ADMIN_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
+    getCategoryAttributes: attributeCode => magento.get(`/V1/categories/attributes/${attributeCode}`, undefined, undefined, ADMIN_TYPE),
 
     getCategoriesList: () => {
       // GET /V1/categories/list
-      return new Promise((resolve, reject) => {
-        const path = '/V1/categories/list';
-        const params = {
-          'searchCriteria[filterGroups][0][filters][0][field]': 'name',
-          'searchCriteria[filterGroups][0][filters][0][value]': 'Woman',
-          'searchCriteria[filterGroups][0][filters][0][conditionType]': 'eq',
-          'searchCriteria[pageSize]': 20,
-          'searchCriteria[currentPage]': 1
-        };
+      const path = '/V1/categories/list';
+      const params = {
+        'searchCriteria[filterGroups][0][filters][0][field]': 'name',
+        'searchCriteria[filterGroups][0][filters][0][value]': 'Woman',
+        'searchCriteria[filterGroups][0][filters][0][conditionType]': 'eq',
+        'searchCriteria[pageSize]': 20,
+        'searchCriteria[currentPage]': 1
+      };
 
-        magento
-          .get(path, params, undefined, ADMIN_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
+      return magento.get(path, params, undefined, ADMIN_TYPE);
     },
 
     /**
@@ -258,214 +178,44 @@ export default magento => {
       return magento.admin.getProductsWithSearchCritaria(params);
     },
 
-    getProductsWithSearchCritaria: (searchCriteria) => {
-      return new Promise((resolve, reject) => {
-        const path = '/V1/products';
+    getProductsWithSearchCritaria: (searchCriteria) => magento.get('/V1/products', searchCriteria, undefined, ADMIN_TYPE),
 
-        magento.get(path, searchCriteria, undefined, ADMIN_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
-
-    getProductBySku: (sku) => {
-      return new Promise((resolve, reject) => {
-        const path = `/V1/products/${sku}`;
-
-        magento.get(path, undefined, undefined, ADMIN_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
+    getProductBySku: (sku) => magento.get(`/V1/products/${sku}`, undefined, undefined, ADMIN_TYPE),
 
     getFeaturedChildren: ({ page, pageSize = 10, filter }) => {
-      return new Promise((resolve, reject) => {
-        let path = '/V1/products?';
-        path += magento.makeParams({ page, pageSize, filter });
-        console.log('PATH:', path);
-        magento
-          .get(path, undefined, undefined, ADMIN_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
+      let path = '/V1/products?';
+      path += magento.makeParams({ page, pageSize, filter });
+      console.log('PATH:', path);
+      return magento.get(path, undefined, undefined, ADMIN_TYPE);
     },
 
-    getConfigurableChildren: (sku) => {
-      return new Promise((resolve, reject) => {
-        const path = `/V1/configurable-products/${sku}/children`;
+    getConfigurableChildren: (sku) => magento.get(`/V1/configurable-products/${sku}/children`, undefined, undefined, ADMIN_TYPE),
 
-        magento.get(path, undefined, undefined, ADMIN_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
+    getConfigurableProductOptions: (sku) => magento.get(`/V1/configurable-products/${sku}/options/all`, undefined, undefined, ADMIN_TYPE),
 
-    getConfigurableProductOptions: (sku) => {
-      return new Promise((resolve, reject) => {
-        const path = `/V1/configurable-products/${sku}/options/all`;
+    getConfigurableProductOptionById: (sku, id) => magento.get(`/V1/configurable-products/${sku}/options/${id}`, undefined, undefined, ADMIN_TYPE),
 
-        magento.get(path, undefined, undefined, ADMIN_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
+    getProductAttributesOptions: (attributeId) => magento.get(`/V1/products/attributes/${attributeId}/options`, undefined, undefined, ADMIN_TYPE),
 
-    getConfigurableProductOptionById: (sku, id) => {
-      return new Promise((resolve, reject) => {
-        const path = `/V1/configurable-products/${sku}/options/${id}`;
+    getAttributeByCode: (attributeCode) => magento.get(`/V1/products/attributes/${attributeCode}`, undefined, undefined, ADMIN_TYPE),
 
-        magento.get(path, undefined, undefined, ADMIN_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
+    getProductMedia: (sku) => magento.get(`/V1/products/${sku}/media`, undefined, undefined, ADMIN_TYPE),
 
-    getProductAttributesOptions: (attributeId) => {
-      return new Promise((resolve, reject) => {
-        const path = `/V1/products/attributes/${attributeId}/options`;
+    getCart: customerId => magento.post(`/V1/customers/${customerId}/carts`, undefined, ADMIN_TYPE),
 
-        magento.get(path, undefined, undefined, ADMIN_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
+    getCmsBlock: id => magento.get(`/V1/cmsBlock/${id}`, undefined, undefined, ADMIN_TYPE),
 
-    getAttributeByCode: (attributeCode) => {
-      return new Promise((resolve, reject) => {
-        const path = `/V1/products/attributes/${attributeCode}`;
-
-        magento.get(path, undefined, undefined, ADMIN_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
-
-    getProductMedia: (sku) => {
-      return new Promise((resolve, reject) => {
-        const path = `/V1/products/${sku}/media`;
-
-        magento.get(path, undefined, undefined, ADMIN_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
-
-    getCart: customerId => {
-      return new Promise((resolve, reject) => {
-        const path = `/V1/customers/${customerId}/carts`;
-
-        magento
-          .post(path, undefined, ADMIN_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
-
-    getCmsBlock: id => {
-      return new Promise((resolve, reject) => {
-        // GET /V1/cmsBlock/:blockId
-        const path = `/V1/cmsBlock/${id}`;
-
-        magento
-          .get(path, undefined, undefined, ADMIN_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
-
-    removeItemFromCart: (cartId, itemId) => {
-      // DELETE /V1/carts/mine/items
-      return new Promise((resolve, reject) => {
-        const path = `/V1/carts/${cartId}/items/${itemId}`;
-
-        magento
-          .delete(path, undefined, ADMIN_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
+    removeItemFromCart: (cartId, itemId) => magento.delete(`/V1/carts/${cartId}/items/${itemId}`, undefined, ADMIN_TYPE),
 
     getOrderList: (customerId) => {
       console.log('getting orders for: ', customerId);
-      return new Promise((resolve, reject) => {
-        const path = '/V1/orders';
-        const params = {
-          'searchCriteria[filterGroups][0][filters][0][field]': 'customer_id',
-          'searchCriteria[filterGroups][0][filters][0][value]': customerId
-        };
 
-        magento
-          .get(path, params, undefined, ADMIN_TYPE)
-          .then(data => {
-            console.log('getOrderList response:', data);
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
+      const path = '/V1/orders';
+      const params = {
+        'searchCriteria[filterGroups][0][filters][0][field]': 'customer_id',
+        'searchCriteria[filterGroups][0][filters][0][value]': customerId
+      };
+      return magento.get(path, params, undefined, ADMIN_TYPE);
     },
-
   };
 };

--- a/src/magento/lib/customer/index.js
+++ b/src/magento/lib/customer/index.js
@@ -1,174 +1,25 @@
-import {CUSTOMER_TYPE} from '../../types';
+import { CUSTOMER_TYPE } from '../../types';
 
 export default magento => {
   return {
-    getCurrentCustomer: () => {
-      // GET /rest/V1/customers/me
-      return new Promise((resolve, reject) => {
-        const path = '/V1/customers/me';
+    getCurrentCustomer: () => magento.get('/V1/customers/me', undefined, undefined, CUSTOMER_TYPE),
 
-        magento
-          .get(path, undefined, undefined, CUSTOMER_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
+    getCustomerCart: () => magento.get('/V1/carts/mine', undefined, undefined, CUSTOMER_TYPE),
 
-    getCustomerCart: () => {
-      // GET /V1/carts/mine
-      return new Promise((resolve, reject) => {
-        const path = '/V1/carts/mine';
+    createCart: customerId => magento.post(`/V1/customers/${customerId}/carts`, undefined, CUSTOMER_TYPE),
 
-        magento
-          .get(path, undefined, undefined, CUSTOMER_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
+    addItemToCart: item => magento.post('/V1/carts/mine/items', item, CUSTOMER_TYPE),
 
-    createCart: customerId => {
-      return new Promise((resolve, reject) => {
-        const path = `/V1/customers/${customerId}/carts`;
+    addCartBillingAddress: (address) => magento.post('/V1/carts/mine/billing-address', address, CUSTOMER_TYPE),
 
-        magento
-          .post(path, undefined, CUSTOMER_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
+    cartEstimateShippingMethods: (address) => magento.post('/V1/carts/mine/estimate-shipping-methods', address, CUSTOMER_TYPE),
 
-    addItemToCart: item => {
-      // POST /V1/carts/mine/items
-      return new Promise((resolve, reject) => {
-        const path = '/V1/carts/mine/items';
+    addCartShippingInfo: (address) => magento.post('/V1/carts/mine/shipping-information', address, CUSTOMER_TYPE),
 
-        magento
-          .post(path, item, CUSTOMER_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
+    getCartShippingMethods: () => magento.get('/V1/carts/mine/estimate-shipping-methods', undefined, undefined, CUSTOMER_TYPE),
 
-    addCartBillingAddress: (address) => {
-      // POST /V1/carts/mine/billing-address
-      return new Promise((resolve, reject) => {
-        const path = '/V1/carts/mine/billing-address';
+    getCartPaymentMethods: () => magento.get('/V1/carts/mine/payment-methods', undefined, undefined, CUSTOMER_TYPE),
 
-        magento
-          .post(path, address, CUSTOMER_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
-
-    cartEstimateShippingMethods: (address) => {
-      // POST /V1/carts/mine/estimate-shipping-methods"
-      return new Promise((resolve, reject) => {
-        const path = '/V1/carts/mine/estimate-shipping-methods';
-
-        magento
-          .post(path, address, CUSTOMER_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
-
-    addCartShippingInfo: (address) => {
-      // POST /V1/carts/mine/shipping-information
-      return new Promise((resolve, reject) => {
-        const path = '/V1/carts/mine/shipping-information';
-
-        magento
-          .post(path, address, CUSTOMER_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
-
-    getCartShippingMethods: () => {
-      // GET /V1/carts/mine/estimate-shipping-methods
-      return new Promise((resolve, reject) => {
-        const path = '/V1/carts/mine/estimate-shipping-methods';
-
-        magento
-          .get(path, undefined, undefined, CUSTOMER_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
-
-    getCartPaymentMethods: () => {
-      // GET /V1/carts/mine/payment-methods
-      return new Promise((resolve, reject) => {
-        const path = '/V1/carts/mine/payment-methods';
-
-        magento
-          .get(path, undefined, undefined, CUSTOMER_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
-
-    placeCartOrder: (payment) => {
-      // PUT /V1/carts/mine/order
-      return new Promise((resolve, reject) => {
-        const path = '/V1/carts/mine/order';
-
-        magento
-          .put(path, payment, CUSTOMER_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
+    placeCartOrder: (payment) => magento.put('/V1/carts/mine/order', payment, CUSTOMER_TYPE),
   };
 };

--- a/src/magento/lib/guest/index.js
+++ b/src/magento/lib/guest/index.js
@@ -2,247 +2,38 @@ import { GUEST_TYPE } from '../../types';
 
 export default magento => {
   return {
-    createGuestCart: () => {
-      return new Promise((resolve, reject) => {
-        const path = '/V1/guest-carts';
+    createGuestCart: () => magento.post('/V1/guest-carts', undefined, GUEST_TYPE),
 
-        magento
-          .post(path, undefined, GUEST_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
+    addItemToCart: (cartId, item) => magento.post(`/V1/guest-carts/${cartId}/items`, item, GUEST_TYPE),
 
-    addItemToCart: (cartId, item) => {
-      // POST /V1/guest-carts/{cartId}/items
-      return new Promise((resolve, reject) => {
-        const path = `/V1/guest-carts/${cartId}/items`;
+    getGuestCart: cartId => magento.get(`/V1/guest-carts/${cartId}`, undefined, undefined, GUEST_TYPE),
 
-        magento
-          .post(path, item, GUEST_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
+    addGuestCartBillingAddress: (cartId, address) => magento.post(`/V1/guest-carts/${cartId}/billing-address`, address, GUEST_TYPE),
 
-    getGuestCart: cartId => {
-      // GET /V1/guest-carts/{cartId}
-      return new Promise((resolve, reject) => {
-        const path = `/V1/guest-carts/${cartId}`;
+    guestCartEstimateShippingMethods: (cartId, address) => magento.post(`/V1/guest-carts/${cartId}/estimate-shipping-methods`, address, GUEST_TYPE),
 
-        magento
-          .get(path, undefined, undefined, GUEST_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
+    addGuestCartShippingInfo: (cartId, address) => magento.post(`/V1/guest-carts/${cartId}/shipping-information`, address, GUEST_TYPE),
 
-    addGuestCartBillingAddress: (cartId, address) => {
-      // POST /V1/guest-carts/{cartId}/billing-address
-      return new Promise((resolve, reject) => {
-        const path = `/V1/guest-carts/${cartId}/billing-address`;
+    getGuestCartPaymentInfo: cartId => magento.get(`/V1/guest-carts/${cartId}/payment-information`, undefined, undefined, GUEST_TYPE),
 
-        magento
-          .post(path, address, GUEST_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
+    getGuestCartPaymentMethods: cartId => magento.get(`/V1/guest-carts/${cartId}/payment-methods`, undefined, undefined, GUEST_TYPE),
 
-    guestCartEstimateShippingMethods: (cartId, address) => {
-      // POST /V1/guest-carts/:cartId/estimate-shipping-methods"
-      return new Promise((resolve, reject) => {
-        const path = `/V1/guest-carts/${cartId}/estimate-shipping-methods`;
+    getGuestCartShippingMethods: cartId => magento.get(`/V1/guest-carts/${cartId}/shipping-methods`, undefined, undefined, GUEST_TYPE),
 
-        magento
-          .post(path, address, GUEST_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
+    placeGuestCartOrder: (cartId, payment) => magento.put(`/V1/guest-carts/${cartId}/order`, payment, GUEST_TYPE),
 
-    addGuestCartShippingInfo: (cartId, address) => {
-      // POST /V1/guest-carts/{cartId}/shipping-information
-      return new Promise((resolve, reject) => {
-        const path = `/V1/guest-carts/${cartId}/shipping-information`;
+    getCountries: () => magento.get('/V1/directory/countries', undefined, undefined, GUEST_TYPE),
 
-        magento
-          .post(path, address, GUEST_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
+    getCountriesByCountryId: countryId => magento.get(`/V1/directory/countries/${countryId}`, undefined, undefined, GUEST_TYPE),
 
-    getGuestCartPaymentInfo: cartId => {
-      // GET /V1/guest-carts/{cartId}/payment-information
-      return new Promise((resolve, reject) => {
-        const path = `/V1/guest-carts/${cartId}/payment-information`;
-
-        magento
-          .get(path, undefined, undefined, GUEST_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
-
-    getGuestCartPaymentMethods: cartId => {
-      // GET /V1/guest-carts/{cartId}/payment-methods
-      return new Promise((resolve, reject) => {
-        const path = `/V1/guest-carts/${cartId}/payment-methods`;
-
-        magento
-          .get(path, undefined, undefined, GUEST_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
-
-    getGuestCartShippingMethods: cartId => {
-      // GET /V1/guest-carts/{cartId}/shipping-methods
-      return new Promise((resolve, reject) => {
-        const path = `/V1/guest-carts/${cartId}/shipping-methods`;
-
-        magento
-          .get(path, undefined, undefined, GUEST_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
-
-    placeGuestCartOrder: (cartId, payment) => {
-      // PUT /V1/guest-carts/{cartId}/order
-      return new Promise((resolve, reject) => {
-        const path = `/V1/guest-carts/${cartId}/order`;
-
-        magento
-          .put(path, payment, GUEST_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
-
-    getCountries: () => {
-      // GET /V1/directory/countries
-      return new Promise((resolve, reject) => {
-        const path = '/V1/directory/countries';
-
-        magento
-          .get(path, undefined, undefined, GUEST_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
-
-    getCountriesByCountryId: countryId => {
-      // GET /V1/directory/countries/:countryId
-      return new Promise((resolve, reject) => {
-        const path = `/V1/directory/countries/${countryId}`;
-
-        magento
-          .get(path, undefined, undefined, GUEST_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
-
-    createCustomer: customer => {
-      // POST /V1/customers
-      return new Promise((resolve, reject) => {
-        const path = '/V1/customers';
-
-        magento
-          .post(path, customer, GUEST_TYPE)
-          .then(data => {
-            resolve(data);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    },
+    createCustomer: customer => magento.post('/V1/customers', customer, GUEST_TYPE),
 
     auth: (username, password) => {
-      return new Promise((resolve, reject) => {
-        if (username) {
-          const path = '/V1/integration/customer/token';
-
-          magento
-            .post(path, { username, password }, GUEST_TYPE)
-            .then(token => {
-              console.log('token');
-              magento.setCustomerToken(token);
-
-              resolve(token);
-            })
-            .catch(e => {
-              console.log(e);
-              reject(e);
-            });
-        } else {
-          reject('Email is required!');
-        }
-      });
+      if (username) {
+        const path = '/V1/integration/customer/token';
+        return magento.post(path, { username, password }, GUEST_TYPE)
+      }
+      throw new Error('Email is required!');
     },
 
     initiatePasswordReset: email => {
@@ -253,19 +44,8 @@ export default magento => {
         websiteId: magento.configuration.websiteId
       };
 
-      return new Promise((resolve, reject) => {
-        const path = '/V1/customers/password';
-
-        magento
-          .put(path, data, GUEST_TYPE)
-          .then(response => {
-            resolve(response);
-          })
-          .catch(e => {
-            console.log(e);
-            reject(e);
-          });
-      });
-    }
+      const path = '/V1/customers/password';
+      return magento.put(path, data, GUEST_TYPE);
+    },
   };
 };


### PR DESCRIPTION
**What does this implement/fix? Explain your changes.**
description: currently the api call 3 nested Promise use into one another, in which one is completely unecessary,
there is no need of promise creation in admin/index.js, customer/index.js, guest/index.js
We can simply reuse promise return from magento/index.js in functions written in admin, guest and customer

**Does this close any currently open issues?**
#64 

**Any other comments?**
This pull request requires complete Testing, to make sure all API are working properly.

**Where has this been tested?**
---------------------------
 - Magento Version: [e.g. 2.1.0]
 - Device: [Android Emulator]
 - OS: [PIE]
 - Version [API level 28]
