### PR TITLE
fix: Product with no custom option throw error

### DIFF
--- a/src/components/catalog/Product.js
+++ b/src/components/catalog/Product.js
@@ -69,7 +69,7 @@ class Product extends Component {
     });
 
     const customOptions = [];
-    Object.keys(selectedCustomOptions).forEach((key) => {
+    selectedCustomOptions && Object.keys(selectedCustomOptions).forEach((key) => {
       console.log(selectedCustomOptions[key]);
       customOptions.push({
         optionId: key,


### PR DESCRIPTION
**What does this implement/fix? Explain your changes.**
When adding product to cart which has no custom options, it throws error, as `selectedCustomOptions` is null and iterating over it will throw error

**Does this close any currently open issues?**
close #73

**Any other comments?**
See #73 issue for more detail

**Where has this been tested?**
---------------------------
 - Magento Version: [2.1.0]
 - Device: [Android Emulator Nexus 5X]
 - OS: [PIE]
 - Version [28]
