### PR TITLE
fix: remove one componentDidMount in CheckoutCustomerAccount & AddAccountAddress

### DIFF
--- a/src/components/account/AddAccountAddress.js
+++ b/src/components/account/AddAccountAddress.js
@@ -17,15 +17,12 @@ import { ThemeContext } from '../../theme';
 class AddAccountAddress extends Component {
   static contextType = ThemeContext;
 
-  componentDidMount() {
-    this.props.getCountries();
-  }
-
   componentWillUnmount() {
     this.props.updateAccountAddressUI('error', false);
   }
 
   componentDidMount() {
+    this.props.getCountries();
     this.props.resetAccountAddressUI();
 
     if (this.props.customer && this.props.customer.addresses && this.props.customer.addresses.length) {

--- a/src/components/checkout/CheckoutCustomerAccount.js
+++ b/src/components/checkout/CheckoutCustomerAccount.js
@@ -19,9 +19,6 @@ class CheckoutCustomerAccount extends Component {
 
   componentDidMount() {
     this.props.getCountries();
-  }
-
-  componentDidMount() {
     // Hardcode US
     // this.props.updateCheckoutUI('countryId', 'US');
     // Clear the error


### PR DESCRIPTION
**What does this implement/fix? Explain your changes.**
In `AddAccountAddress` and `CheckoutCustomerAccount` screen, `componentDidMount` function is written twice, which will result in only one of the function being called, remove one

**Does this close any currently open issues?**
close #89 

**Any other comments?**
App is not tested in iOS

**Where has this been tested?**
---------------------------
 - Magento Version: [2.1.0]
 - Device: [Android Emulator Nexus 5X]
 - OS: [PIE]
 - Version [Andorid API 28]
