### PR TITLE
Final price functionality to display the discounted price

### DIFF
--- a/src/components/catalog/Product.js
+++ b/src/components/catalog/Product.js
@@ -21,6 +21,7 @@ import ProductMedia from './ProductMedia';
 import { logError } from '../../helper/logger';
 import { ThemeContext } from '../../theme';
 import { translate } from '../../i18n';
+import { finalPrice } from '../../helper/helper';
 
 class Product extends Component {
   static contextType = ThemeContext;
@@ -310,7 +311,7 @@ class Product extends Component {
     if (selectedProduct) {
       return selectedProduct.price;
     }
-    return this.props.product.price;
+    return finalPrice(this.props.product.custom_attributes,this.props.product.price);
   }
 
   renderProductMedia = () => {

--- a/src/components/common/ProductListItem.js
+++ b/src/components/common/ProductListItem.js
@@ -5,6 +5,7 @@ import FastImage from 'react-native-fast-image';
 import { Text } from './Text';
 import { getProductThumbnailFromAttribute } from '../../helper/product';
 import { ThemeContext } from '../../theme';
+import { finalPrice } from '../../helper/helper';
 
 const ProductListItem = ({
   product,
@@ -35,7 +36,7 @@ const ProductListItem = ({
         <View style={[styles.infoStyle, infoStyle]}>
           <Text type="subheading" style={[styles.textStyle(theme), textStyle]}>{product.name}</Text>
           <Text type="heading" style={[styles.priceStyle(theme), priceStyle]}>
-            {`${currencySymbol} ${product.price}`}
+            {`${currencySymbol} ${finalPrice(product.custom_attributes, product.price)}`}
           </Text>
         </View>
       </TouchableOpacity>

--- a/src/components/home/FeaturedProductItem.js
+++ b/src/components/home/FeaturedProductItem.js
@@ -5,6 +5,7 @@ import FastImage from 'react-native-fast-image';
 import { Text } from '../common';
 import { getProductThumbnailFromAttribute } from '../../helper/product';
 import { ThemeContext } from '../../theme';
+import { finalPrice } from '../../helper/helper';
 
 const FeaturedProductItem = ({
   onPress,
@@ -36,7 +37,7 @@ const FeaturedProductItem = ({
             type="caption"
             style={styles.priceStyle}
           >
-            {`${currencySymbol} ${product.price}`}
+            {`${currencySymbol} ${finalPrice(product.custom_attributes, product.price)}`}
           </Text>
         </View>
       </TouchableOpacity>

--- a/src/helper/helper.js
+++ b/src/helper/helper.js
@@ -1,0 +1,9 @@
+export function finalPrice(data, price) {
+  let specialPrice = price;
+  const result = data.filter(item => item.attribute_code === 'special_price');
+  if (result.length) {
+    const splittedValue = result[0].value.split('.');
+    specialPrice = splittedValue[0];
+  }
+  return specialPrice;
+}


### PR DESCRIPTION
Hello Dmytro, 
There is a default price was listing even if there is a special price is available. The changes contain a functionality that checks the availability of a special price and replaces the price.

**Does this close any currently open issues?**
[Add sales price for products #92](https://github.com/troublediehard/magento-react-native/issues/92#issue-509587472)


![Screenshot_20191120-202310](https://user-images.githubusercontent.com/13719000/69249399-cd625500-0bd3-11ea-8c66-aa56cc36173a.png)
![Screenshot_20191120-202316](https://user-images.githubusercontent.com/13719000/69249401-cdfaeb80-0bd3-11ea-83af-a7373a08897b.png)
