### PR TITLE
Feature/multiple currency support

### DIFF
--- a/src/components/account/OrderListItem.js
+++ b/src/components/account/OrderListItem.js
@@ -5,17 +5,18 @@ import {
   TouchableOpacity,
 } from 'react-native';
 import PropTypes from 'prop-types';
-import { Text } from '../common';
+import { Text, Price } from '../common';
 import { NAVIGATION_ORDER_PATH } from '../../navigation/routes';
 import NavigationService from '../../navigation/NavigationService';
 import { ThemeContext } from '../../theme';
 import { translate } from '../../i18n';
+import { priceSignByCode } from '../../helper/price';
 
 const OrderListItem = ({
   item,
-  currencySymbol,
 }) => {
   const theme = useContext(ThemeContext);
+  const currencySymbol = priceSignByCode(item.order_currency_code);
 
   const openOrdersScreen = () => {
     NavigationService.navigate(NAVIGATION_ORDER_PATH, {
@@ -31,9 +32,16 @@ const OrderListItem = ({
         <Text type="label">
           {`${translate('orderListItem.shipTo')} ${item.customer_firstname} ${item.customer_lastname}`}
         </Text>
-        <Text type="label">
-          {`${translate('orderListItem.orderTotal')}: ${currencySymbol} ${item.grand_total}`}
-        </Text>
+        <View style={styles.row}>
+          <Text type="label">
+            {`${translate('orderListItem.orderTotal')}: `}
+          </Text>
+          <Price
+            basePrice={item.grand_total}
+            currencySymbol={currencySymbol}
+            currencyRate={1}
+          />
+        </View>
         <Text type="label">{`${translate('orderListItem.status')}: ${item.status}`}</Text>
       </View>
     </TouchableOpacity>
@@ -50,6 +58,9 @@ const styles = StyleSheet.create({
     borderColor: theme.colors.border,
     flex: 1,
   }),
+  row: {
+    flexDirection: 'row',
+  },
 });
 
 OrderListItem.propTypes = {

--- a/src/components/account/OrderScreen.js
+++ b/src/components/account/OrderScreen.js
@@ -3,19 +3,20 @@ import { View, StyleSheet, FlatList } from 'react-native';
 import FastImage from 'react-native-fast-image';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { Text } from '../common';
+import { Text, Price } from '../common';
 import { orderProductDetail } from '../../actions';
 import { getProductThumbnailFromAttribute } from '../../helper/product';
 import { ThemeContext } from '../../theme';
 import { translate } from '../../i18n';
+import { priceSignByCode } from '../../helper/price';
 
 const OrderScreen = ({
   products,
   navigation,
-  currencySymbol,
   orderProductDetail: _orderProductDetail,
 }) => {
   const theme = useContext(ThemeContext);
+  const currencySymbol = priceSignByCode(navigation.state.params.item.order_currency_code);
 
   useEffect(() => {
     navigation.state.params.item.items.forEach((item) => {
@@ -38,11 +39,25 @@ const OrderScreen = ({
         <View>
           <Text bold>{item.item.name}</Text>
           <Text type="label">{`${translate('common.sku')}: ${item.item.sku}`}</Text>
-          <Text type="label">
-            {`${translate('common.price')}: ${currencySymbol} ${item.item.price}`}
-          </Text>
+          <View style={styles.row}>
+            <Text type="label">
+              {`${translate('common.price')}: `}
+            </Text>
+            <Price
+              currencyRate={1}
+              currencySymbol={currencySymbol}
+              basePrice={item.item.price}
+            />
+          </View>
           <Text type="label">{`${translate('common.quantity')}: ${item.item.qty_ordered}`}</Text>
-          <Text type="label">{`${translate('common.subTotal')}: ${currencySymbol} ${item.item.row_total}`}</Text>
+          <View style={styles.row}>
+            <Text type="label">{`${translate('common.subTotal')}: `}</Text>
+            <Price
+              basePrice={item.item.row_total}
+              currencyRate={1}
+              currencySymbol={currencySymbol}
+            />
+          </View>
         </View>
       </View>
     </View>
@@ -58,15 +73,36 @@ const OrderScreen = ({
         keyExtractor={(_item, index) => index.toString()}
       />
       <Text type="label">{`${translate('orderListItem.status')}: ${item.status}`}</Text>
-      <Text type="label">
-        {`${translate('common.subTotal')}: ${currencySymbol} ${item.subtotal}`}
-      </Text>
-      <Text type="label">
-        {`${translate('orderListItem.shippingAndHandling')}: ${currencySymbol} ${item.shipping_amount}`}
-      </Text>
-      <Text type="label" bold>
-        {`${translate('common.grandTotal')}: ${currencySymbol} ${item.total_due}`}
-      </Text>
+      <View style={styles.row}>
+        <Text type="label">
+          {`${translate('common.subTotal')}: `}
+        </Text>
+        <Price
+          basePrice={item.subtotal}
+          currencyRate={1}
+          currencySymbol={currencySymbol}
+        />
+      </View>
+      <View style={styles.row}>
+        <Text type="label">
+          {`${translate('orderListItem.shippingAndHandling')}: `}
+        </Text>
+        <Price
+          basePrice={item.shipping_amount}
+          currencyRate={1}
+          currencySymbol={currencySymbol}
+        />
+      </View>
+      <View style={styles.row}>
+        <Text type="label" bold>
+          {`${translate('common.grandTotal')}: `}
+        </Text>
+        <Price
+          basePrice={item.total_due}
+          currencyRate={1}
+          currencySymbol={currencySymbol}
+        />
+      </View>
     </View>
   );
 };
@@ -90,7 +126,6 @@ const styles = StyleSheet.create({
     flex: 1,
   }),
   row: {
-    flex: 1,
     flexDirection: 'row',
   },
   imageStyle: theme => ({
@@ -102,7 +137,6 @@ const styles = StyleSheet.create({
 OrderScreen.propTypes = {
   products: PropTypes.object.isRequired,
   navigation: PropTypes.object.isRequired,
-  currencySymbol: PropTypes.string.isRequired,
   orderProductDetail: PropTypes.func.isRequired,
 };
 
@@ -110,10 +144,8 @@ OrderScreen.defaultProps = {};
 
 const mapStateToProps = ({ account, magento }) => {
   const { products } = account;
-  const { default_display_currency_symbol: currencySymbol } = magento.currency;
   return {
     products,
-    currencySymbol,
   };
 };
 

--- a/src/components/account/OrdersScreen.js
+++ b/src/components/account/OrdersScreen.js
@@ -21,7 +21,6 @@ import { NAVIGATION_HOME_SCREEN_PATH } from '../../navigation/routes';
 const OrdersScreen = ({
   orders,
   customerId,
-  currencySymbol,
   refreshing,
   getOrdersForCustomer: _getOrdersForCustomer,
   navigation,
@@ -37,7 +36,9 @@ const OrdersScreen = ({
   };
 
   const renderItem = orderItem => (
-    <OrderListItem item={orderItem.item} currencySymbol={currencySymbol} />
+    <OrderListItem
+      item={orderItem.item}
+    />
   );
 
   const renderOrderList = () => {
@@ -115,7 +116,6 @@ const styles = {
 OrdersScreen.propTypes = {
   orders: PropTypes.arrayOf(PropTypes.object),
   customerId: PropTypes.number,
-  currencySymbol: PropTypes.string.isRequired,
   refreshing: PropTypes.bool,
   getOrdersForCustomer: PropTypes.func.isRequired,
   navigation: PropTypes.object.isRequired,
@@ -128,13 +128,11 @@ OrdersScreen.defaultProps = {
 
 const mapStateToProps = ({ account, magento }) => {
   const customerId = account.customer ? account.customer.id : null;
-  const { default_display_currency_symbol: currencySymbol } = magento.currency;
   const orders = account.orderData ? account.orderData.items : [];
   return {
     customerId,
     orders,
     refreshing: account.refreshing,
-    currencySymbol,
   };
 };
 

--- a/src/components/cart/Cart.js
+++ b/src/components/cart/Cart.js
@@ -15,7 +15,7 @@ import {
   NAVIGATION_CHECKOUT_PATH,
   NAVIGATION_HOME_SCREEN_PATH,
 } from '../../navigation/routes';
-import { Button, Text } from '../common';
+import { Button, Text, Price } from '../common';
 import { ThemeContext } from '../../theme';
 import { translate } from '../../i18n';
 
@@ -97,9 +97,16 @@ class Cart extends Component {
 
     if (sum > 0) {
       return (
-        <Text type="heading" style={totals(theme)}>
-          {`${translate('common.total')} ${sum.toFixed(2)}`}
-        </Text>
+        <View style={styles.totalPriceContainer}>
+          <Text type="heading">
+            {`${translate('common.total')} `}
+          </Text>
+          <Price
+            currencyRate={this.props.currencyRate}
+            currencySymbol={this.props.currencySymbol}
+            basePrice={sum}
+          />
+        </View>
       );
     }
   }
@@ -130,7 +137,14 @@ class Cart extends Component {
     );
   };
 
-  renderItem = items => <CartListItem item={items.item} expanded={false} />
+  renderItem = items => (
+    <CartListItem
+      expanded={false}
+      item={items.item}
+      currencyRate={this.props.currencyRate}
+      currencySymbol={this.props.currencySymbol}
+    />
+  );
 
   renderCart = () => {
     const theme = this.context;
@@ -197,6 +211,10 @@ const styles = StyleSheet.create({
   totals: theme => ({
     paddingTop: theme.spacing.small,
   }),
+  totalPriceContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
   buttonTextStyle: theme => ({
     padding: theme.spacing.large,
     top: 0,
@@ -212,12 +230,20 @@ const styles = StyleSheet.create({
   }),
 });
 
-const mapStateToProps = ({ cart }) => {
+const mapStateToProps = ({ cart, magento }) => {
   const { products } = cart;
+  const {
+    currency: {
+      displayCurrencySymbol: currencySymbol,
+      displayCurrencyExchangeRate: currencyRate,
+    },
+  } = magento;
   return {
+    products,
+    currencyRate,
+    currencySymbol,
     cart: cart.quote,
     refreshing: cart.refreshing,
-    products,
   };
 };
 

--- a/src/components/cart/CartListItem.js
+++ b/src/components/cart/CartListItem.js
@@ -4,17 +4,18 @@ import FastImage from 'react-native-fast-image';
 import { Icon } from 'react-native-elements';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { magento } from '../../magento';
 import { getProductThumbnailFromAttribute } from '../../helper/product';
-import { Spinner, Text } from '../common';
+import { Spinner, Text, Price } from '../common';
 import { removeFromCartLoading, removeFromCart } from '../../actions';
 import { ThemeContext } from '../../theme';
 import { translate } from '../../i18n';
 
 const CartListItem = ({
-  products,
   item,
   cart,
+  products,
+  currencyRate,
+  currencySymbol,
   removeFromCartLoading: _removeFromCartLoading,
   removeFromCart: _removeFromCart,
 }) => {
@@ -54,9 +55,13 @@ const CartListItem = ({
       <FastImage style={styles.imageStyle(theme)} resizeMode="contain" source={{ uri: imageUri }} />
       <View style={styles.infoStyle}>
         <Text style={styles.textStyle(theme)}>{item.name}</Text>
-        <Text style={styles.textStyle(theme)}>
-          {`${magento.storeConfig.default_display_currency_code} ${item.price}`}
-        </Text>
+        <View style={styles.textStyle(theme)}>
+          <Price
+            basePrice={item.price}
+            currencySymbol={currencySymbol}
+            currencyRate={currencyRate}
+          />
+        </View>
         <Text style={styles.textStyle(theme)}>
           {`${translate('common.quantity')}: ${item.qty}`}
         </Text>
@@ -129,6 +134,8 @@ CartListItem.propTypes = {
   products: PropTypes.object,
   item: PropTypes.object.isRequired,
   cart: PropTypes.object.isRequired,
+  currencySymbol: PropTypes.string.isRequired,
+  currencyRate: PropTypes.number.isRequired,
   removeFromCartLoading: PropTypes.func.isRequired,
   removeFromCart: PropTypes.func.isRequired,
 };
@@ -139,7 +146,10 @@ CartListItem.defaultProps = {
 
 const mapStateToProps = ({ cart }) => {
   const { products } = cart;
-  return { products, cart };
+  return {
+    cart,
+    products,
+  };
 };
 
 export default connect(mapStateToProps, { removeFromCartLoading, removeFromCart })(CartListItem);

--- a/src/components/catalog/Category.js
+++ b/src/components/catalog/Category.js
@@ -29,6 +29,7 @@ const Category = ({
   refreshing,
   navigation,
   currencySymbol,
+  currencyRate,
   addFilterData: _addFilterData,
   getProductsForCategoryOrChild: _getProductsForCategoryOrChild,
   setCurrentProduct: _setCurrentProduct,
@@ -87,6 +88,7 @@ const Category = ({
         performSort={performSort}
         sortOrder={sortOrder}
         currencySymbol={currencySymbol}
+        currencyRate={currencyRate}
       />
     </View>
   );
@@ -114,6 +116,7 @@ Category.propTypes = {
   refreshing: PropTypes.bool.isRequired,
   navigation: PropTypes.object.isRequired,
   currencySymbol: PropTypes.string.isRequired,
+  currencyRate: PropTypes.number.isRequired,
   addFilterData: PropTypes.func.isRequired,
   getProductsForCategoryOrChild: PropTypes.func.isRequired,
   setCurrentProduct: PropTypes.func.isRequired,
@@ -127,7 +130,12 @@ const mapStateToProps = (state) => {
   const {
     products, totalCount, loadingMore, refreshing,
   } = state.category;
-  const { default_display_currency_symbol: currencySymbol } = state.magento.currency;
+  const {
+    currency: {
+      displayCurrencySymbol: currencySymbol,
+      displayCurrencyExchangeRate: currencyRate,
+    },
+  } = state.magento;
   const { priceFilter, sortOrder } = state.filters;
   const canLoadMoreContent = products.length < totalCount;
 
@@ -141,6 +149,7 @@ const mapStateToProps = (state) => {
     priceFilter,
     sortOrder,
     currencySymbol,
+    currencyRate,
   };
 };
 

--- a/src/components/catalog/DrawerScreen.js
+++ b/src/components/catalog/DrawerScreen.js
@@ -4,6 +4,7 @@ import {
   View,
   StyleSheet,
 } from 'react-native';
+import PropTypes from 'prop-types';
 import {
   getProductsForCategoryOrChild, addFilterData, getSearchProducts,
 } from '../../actions';
@@ -14,9 +15,13 @@ import { translate } from '../../i18n';
 class DrawerScreen extends Component {
   static contextType = ThemeContext;
 
-  static propTypes = {};
+  static propTypes = {
+    currencyRate: PropTypes.number,
+  };
 
-  static defaultProps = {};
+  static defaultProps = {
+    currencyRate: 1,
+  };
 
   state = {
     maxValue: '',
@@ -24,10 +29,11 @@ class DrawerScreen extends Component {
   };
 
   onApplyPressed = () => {
+    const { currencyRate } = this.props;
     const priceFilter = {
       price: {
         condition: 'from,to',
-        value: `${this.state.minValue},${this.state.maxValue}`,
+        value: `${(this.state.minValue / currencyRate).toFixed(2)},${(this.state.maxValue / currencyRate).toFixed(2)}`,
       },
     };
     this.props.addFilterData(priceFilter);
@@ -117,10 +123,16 @@ const styles = StyleSheet.create({
   },
 });
 
-const mapStateToProps = ({ category, filters, search }) => {
+const mapStateToProps = ({ category, filters, search, magento }) => {
   const currentCategory = category.current.category;
   const { searchInput } = search;
-  return { category: currentCategory, filters, searchInput };
+  const { currency: { displayCurrencyExchangeRate: currencyRate } } = magento;
+  return {
+    filters,
+    searchInput,
+    currencyRate,
+    category: currentCategory,
+  };
 };
 
 export default connect(mapStateToProps, {

--- a/src/components/catalog/Product.js
+++ b/src/components/catalog/Product.js
@@ -21,7 +21,7 @@ import ProductMedia from './ProductMedia';
 import { logError } from '../../helper/logger';
 import { ThemeContext } from '../../theme';
 import { translate } from '../../i18n';
-import { finalPrice } from '../../helper/helper';
+import { finalPrice } from '../../helper/price';
 
 class Product extends Component {
   static contextType = ThemeContext;

--- a/src/components/catalog/Product.js
+++ b/src/components/catalog/Product.js
@@ -15,7 +15,7 @@ import {
   uiProductCustomOptionUpdate,
   getCustomOptions,
 } from '../../actions';
-import { Spinner, ModalSelect, Button, Text, Input } from '../common';
+import { Spinner, ModalSelect, Button, Text, Input, Price } from '../common';
 import { getProductCustomAttribute } from '../../helper/product';
 import ProductMedia from './ProductMedia';
 import { logError } from '../../helper/logger';
@@ -27,7 +27,8 @@ class Product extends Component {
   static contextType = ThemeContext;
 
   static propTypes = {
-    currencySymbol: PropTypes.string,
+    currencySymbol: PropTypes.string.isRequired,
+    currencyRate: PropTypes.number.isRequired,
     uiProductCustomOptionUpdate: PropTypes.func,
     getConfigurableProductOptions: PropTypes.func,
     getCustomOptions: PropTypes.func,
@@ -309,9 +310,24 @@ class Product extends Component {
   renderPrice = () => {
     const { selectedProduct } = this.state;
     if (selectedProduct) {
-      return selectedProduct.price;
+      return (
+        <Price
+          style={styles.priceContainer}
+          basePrice={selectedProduct.price}
+          currencySymbol={this.props.currencySymbol}
+          currencyRate={this.props.currencyRate}
+        />
+      );
     }
-    return finalPrice(this.props.product.custom_attributes,this.props.product.price);
+    return (
+      <Price
+        style={styles.priceContainer}
+        basePrice={this.props.product.price}
+        discountPrice={finalPrice(this.props.product.custom_attributes, this.props.product.price)}
+        currencySymbol={this.props.currencySymbol}
+        currencyRate={this.props.currencyRate}
+      />
+    );
   }
 
   renderProductMedia = () => {
@@ -341,9 +357,7 @@ class Product extends Component {
       >
         {this.renderProductMedia()}
         <Text type="heading" bold style={styles.textStyle(theme)}>{this.props.product.name}</Text>
-        <Text type="subheading" bold style={styles.textStyle(theme)}>
-          {`${this.props.currencySymbol}${this.renderPrice()}`}
-        </Text>
+        {this.renderPrice()}
         <Text bold style={styles.textStyle(theme)}>{translate('common.quantity')}</Text>
         <Input
           containerStyle={styles.inputContainer(theme)}
@@ -396,12 +410,20 @@ const styles = StyleSheet.create({
     padding: theme.spacing.small,
     color: theme.colors.error,
   }),
+  priceContainer: {
+    alignSelf: 'center',
+  },
 });
 
 const mapStateToProps = (state) => {
   const { product, options, medias, customOptions } = state.product.current;
   const { attributes, selectedOptions, selectedCustomOptions } = state.product;
-  const { default_display_currency_symbol: currencySymbol } = state.magento.currency;
+  const {
+    currency: {
+      displayCurrencySymbol: currencySymbol,
+      displayCurrencyExchangeRate: currencyRate,
+    },
+  } = state.magento;
   const { cart, account } = state;
   console.log('Product Component');
   console.log(state.product);
@@ -412,6 +434,7 @@ const mapStateToProps = (state) => {
     product,
     options,
     attributes,
+    currencyRate,
     customOptions,
     currencySymbol,
     selectedOptions,

--- a/src/components/checkout/CheckoutShippingMethod.js
+++ b/src/components/checkout/CheckoutShippingMethod.js
@@ -83,14 +83,14 @@ class CheckoutShippingMethod extends Component {
 
   renderShippingMethods() {
     const theme = this.context;
-    const { shipping } = this.props;
+    const { shipping, currencySymbol, currencyRate } = this.props;
 
     if (!shipping || !shipping.length) {
       return <Text>{translate('checkout.noShippingMethod')}</Text>;
     }
 
     const radioProps = shipping.map((item) => {
-      const label = `${item.carrier_title} - ${item.method_title} - ${item.amount}`;
+      const label = `${item.carrier_title} - ${item.method_title} - ${currencySymbol + (item.base_amount * currencyRate).toFixed(2)}`;
       return {
         label,
         value: item,
@@ -168,7 +168,7 @@ const styles = {
   }),
 };
 
-const mapStateToProps = ({ cart, checkout }) => {
+const mapStateToProps = ({ cart, checkout, magento }) => {
   const {
     email,
     password,
@@ -183,6 +183,12 @@ const mapStateToProps = ({ cart, checkout }) => {
     region,
     loading,
   } = checkout.ui;
+  const {
+    currency: {
+      displayCurrencySymbol: currencySymbol,
+      displayCurrencyExchangeRate: currencyRate,
+    },
+  } = magento;
 
   const { shipping, selectedShipping } = checkout;
   const { cartId } = cart;
@@ -203,6 +209,8 @@ const mapStateToProps = ({ cart, checkout }) => {
     loading,
     shipping,
     selectedShipping,
+    currencySymbol,
+    currencyRate,
   };
 };
 

--- a/src/components/common/Price.js
+++ b/src/components/common/Price.js
@@ -1,0 +1,63 @@
+import React, { useContext } from 'react';
+import { View } from 'react-native';
+import PropTypes from 'prop-types';
+import { Text } from './Text';
+import { ThemeContext } from '../../theme';
+
+const formatPrice = (price, currencyRate) => parseFloat((price * currencyRate).toFixed(2));
+
+/**
+ * Component to display price of the product. If discount price is
+ * available, then base price will be crossed off
+ *
+ * @param {Object} props                             - props of the component
+ * @param {number} [props.basePrice = 0]             - default selling price of the product
+ * @param {number} [props.discountPrice = 0]         - special or discount price for the product
+ * @param {string} props.currencySymbol              - currency symbol to append before price
+ * @param {string} props.currencyRate                - currency rate which must be multiply with the actual price.
+ *
+ * @return React component
+ */
+const Price = ({
+  currencySymbol,
+  currencyRate,
+  basePrice,
+  discountPrice,
+}) => {
+  const theme = useContext(ThemeContext);
+  const isBold = () => discountPrice && discountPrice < basePrice;
+  const renderDiscountPrice = () => (discountPrice === basePrice ? null : <Text type="label" bold={isBold()} style={styles.discountPriceText(theme)}>{`${currencySymbol} ${formatPrice(discountPrice, currencyRate)}`}</Text>);
+
+  return (
+    <View style={styles.container}>
+      {discountPrice ? renderDiscountPrice() : null}
+      <Text type="label" bold={!isBold()} style={styles.basePriceText(basePrice, discountPrice)}>{`${currencySymbol} ${formatPrice(basePrice, currencyRate)}`}</Text>
+    </View>
+  );
+};
+
+const styles = {
+  container: {
+    flexDirection: 'row',
+  },
+  discountPriceText: theme => ({
+    marginEnd: theme.spacing.tiny,
+  }),
+  basePriceText: (basePrice, discountPrice) => ({
+    textDecorationLine: discountPrice && discountPrice < basePrice ? 'line-through' : 'none',
+  }),
+};
+
+Price.propTypes = {
+  currencySymbol: PropTypes.string.isRequired,
+  currencyRate: PropTypes.number.isRequired,
+  basePrice: PropTypes.number,
+  discountPrice: PropTypes.number,
+};
+
+Price.defaultProps = {
+  basePrice: 0,
+  discountPrice: 0,
+};
+
+export { Price };

--- a/src/components/common/Price.js
+++ b/src/components/common/Price.js
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { View } from 'react-native';
+import { View, ViewPropTypes } from 'react-native';
 import PropTypes from 'prop-types';
 import { Text } from './Text';
 import { ThemeContext } from '../../theme';
@@ -15,6 +15,7 @@ const formatPrice = (price, currencyRate) => parseFloat((price * currencyRate).t
  * @param {number} [props.discountPrice = 0]         - special or discount price for the product
  * @param {string} props.currencySymbol              - currency symbol to append before price
  * @param {string} props.currencyRate                - currency rate which must be multiply with the actual price.
+ * @param {string} props.style                       - style related to price container
  *
  * @return React component
  */
@@ -23,14 +24,15 @@ const Price = ({
   currencyRate,
   basePrice,
   discountPrice,
+  style,
 }) => {
   const theme = useContext(ThemeContext);
   const isBold = () => discountPrice && discountPrice < basePrice;
   const renderDiscountPrice = () => (discountPrice === basePrice ? null : <Text type="label" bold={isBold()} style={styles.discountPriceText(theme)}>{`${currencySymbol} ${formatPrice(discountPrice, currencyRate)}`}</Text>);
 
   return (
-    <View style={styles.container}>
-      {discountPrice ? renderDiscountPrice() : null}
+    <View style={[styles.container, style]}>
+      {discountPrice && discountPrice < basePrice ? renderDiscountPrice() : null}
       <Text type="label" bold={!isBold()} style={styles.basePriceText(basePrice, discountPrice)}>{`${currencySymbol} ${formatPrice(basePrice, currencyRate)}`}</Text>
     </View>
   );
@@ -53,11 +55,13 @@ Price.propTypes = {
   currencyRate: PropTypes.number.isRequired,
   basePrice: PropTypes.number,
   discountPrice: PropTypes.number,
+  style: ViewPropTypes.style,
 };
 
 Price.defaultProps = {
   basePrice: 0,
   discountPrice: 0,
+  style: {},
 };
 
 export { Price };

--- a/src/components/common/ProductList.js
+++ b/src/components/common/ProductList.js
@@ -36,6 +36,7 @@ const sortData = [
 const ProductList = ({
   onRowPress,
   currencySymbol,
+  currencyRate,
   performSort,
   navigation,
   canLoadMoreContent,
@@ -55,6 +56,7 @@ const ProductList = ({
       product={item}
       onRowPress={onRowPress}
       currencySymbol={currencySymbol}
+      currencyRate={currencyRate}
     />
   );
 
@@ -68,10 +70,10 @@ const ProductList = ({
       columnContainerStyle={styles.columnContainerStyle}
       textStyle={styles.textStyle}
       infoStyle={styles.infoStyle}
-      priceStyle={styles.priceStyle}
       product={item}
       onRowPress={onRowPress}
       currencySymbol={currencySymbol}
+      currencyRate={currencyRate}
     />
   );
 
@@ -170,6 +172,7 @@ const styles = StyleSheet.create({
   infoStyle: {
     flexDirection: 'column',
     justifyContent: 'center',
+    alignItems: 'center',
   },
   textStyle: {
     justifyContent: 'center',
@@ -177,9 +180,6 @@ const styles = StyleSheet.create({
     flexDirection: 'column',
     marginTop: 0,
     padding: 0,
-  },
-  priceStyle: {
-    textAlign: 'center',
   },
   imageStyle: {
     flex: 1,
@@ -216,6 +216,7 @@ const styles = StyleSheet.create({
 ProductList.propTypes = {
   onRowPress: PropTypes.func,
   currencySymbol: PropTypes.string.isRequired,
+  currencyRate: PropTypes.number.isRequired,
   performSort: PropTypes.func,
   navigation: PropTypes.object.isRequired,
   canLoadMoreContent: PropTypes.bool.isRequired,

--- a/src/components/common/ProductListItem.js
+++ b/src/components/common/ProductListItem.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { View, TouchableOpacity } from 'react-native';
 import FastImage from 'react-native-fast-image';
 import { Text } from './Text';
+import { Price } from './Price';
 import { getProductThumbnailFromAttribute } from '../../helper/product';
 import { ThemeContext } from '../../theme';
 import { finalPrice } from '../../helper/price';
@@ -11,6 +12,7 @@ const ProductListItem = ({
   product,
   onRowPress,
   currencySymbol,
+  currencyRate,
   imageStyle,
   infoStyle,
   textStyle,
@@ -35,9 +37,13 @@ const ProductListItem = ({
         />
         <View style={[styles.infoStyle, infoStyle]}>
           <Text type="subheading" style={[styles.textStyle(theme), textStyle]}>{product.name}</Text>
-          <Text type="heading" style={[styles.priceStyle(theme), priceStyle]}>
-            {`${currencySymbol} ${finalPrice(product.custom_attributes, product.price)}`}
-          </Text>
+          <Price
+            style={styles.textStyle(theme)}
+            basePrice={product.price}
+            discountPrice={finalPrice(product.custom_attributes, product.price)}
+            currencyRate={currencyRate}
+            currencySymbol={currencySymbol}
+          />
         </View>
       </TouchableOpacity>
     </View>
@@ -63,10 +69,11 @@ ProductListItem.propTypes = {
   viewContainerStyle: PropTypes.object,
   columnContainerStyle: PropTypes.object,
   currencySymbol: PropTypes.string.isRequired,
+  currencyRate: PropTypes.number.isRequired,
 };
 
 ProductListItem.defaultProps = {
-  onRowPress: () => {},
+  onRowPress: () => { },
   imageStyle: {},
   infoStyle: {},
   textStyle: {},
@@ -87,14 +94,8 @@ const styles = {
     flex: 2,
   },
   textStyle: theme => ({
-    flex: 1,
     padding: theme.spacing.small,
-    marginTop: theme.spacing.large,
-  }),
-  priceStyle: theme => ({
-    flex: 1,
-    padding: theme.spacing.small,
-    paddingTop: 0,
+    marginBottom: theme.spacing.medium,
   }),
   imageStyle: theme => ({
     height: theme.dimens.productListItemImageHeight,

--- a/src/components/common/ProductListItem.js
+++ b/src/components/common/ProductListItem.js
@@ -5,7 +5,7 @@ import FastImage from 'react-native-fast-image';
 import { Text } from './Text';
 import { getProductThumbnailFromAttribute } from '../../helper/product';
 import { ThemeContext } from '../../theme';
-import { finalPrice } from '../../helper/helper';
+import { finalPrice } from '../../helper/price';
 
 const ProductListItem = ({
   product,

--- a/src/components/common/index.js
+++ b/src/components/common/index.js
@@ -9,3 +9,4 @@ export * from './Text';
 export * from './ProductList';
 export * from './ProductListHeaderIcon';
 export * from './ProductListItem';
+export * from './Price';

--- a/src/components/home/FeaturedProductItem.js
+++ b/src/components/home/FeaturedProductItem.js
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { StyleSheet, TouchableOpacity, View } from 'react-native';
 import FastImage from 'react-native-fast-image';
-import { Text } from '../common';
+import { Text, Price } from '../common';
 import { getProductThumbnailFromAttribute } from '../../helper/product';
 import { ThemeContext } from '../../theme';
 import { finalPrice } from '../../helper/price';
@@ -10,6 +10,7 @@ import { finalPrice } from '../../helper/price';
 const FeaturedProductItem = ({
   onPress,
   currencySymbol,
+  currencyRate,
   product,
 }) => {
   const theme = useContext(ThemeContext);
@@ -33,12 +34,12 @@ const FeaturedProductItem = ({
           >
             {product.name}
           </Text>
-          <Text
-            type="caption"
-            style={styles.priceStyle}
-          >
-            {`${currencySymbol} ${finalPrice(product.custom_attributes, product.price)}`}
-          </Text>
+          <Price
+            basePrice={product.price}
+            discountPrice={finalPrice(product.custom_attributes, product.price)}
+            currencySymbol={currencySymbol}
+            currencyRate={currencyRate}
+          />
         </View>
       </TouchableOpacity>
     </View>
@@ -63,6 +64,7 @@ const styles = StyleSheet.create({
   infoStyle: {
     flexDirection: 'column',
     justifyContent: 'center',
+    alignItems: 'center',
   },
   textStyle: theme => ({
     justifyContent: 'center',
@@ -81,6 +83,7 @@ const styles = StyleSheet.create({
 
 FeaturedProductItem.propTypes = {
   currencySymbol: PropTypes.string.isRequired,
+  currencyRate: PropTypes.number.isRequired,
   onPress: PropTypes.func,
   product: PropTypes.object,
 };

--- a/src/components/home/FeaturedProductItem.js
+++ b/src/components/home/FeaturedProductItem.js
@@ -5,7 +5,7 @@ import FastImage from 'react-native-fast-image';
 import { Text } from '../common';
 import { getProductThumbnailFromAttribute } from '../../helper/product';
 import { ThemeContext } from '../../theme';
-import { finalPrice } from '../../helper/helper';
+import { finalPrice } from '../../helper/price';
 
 const FeaturedProductItem = ({
   onPress,

--- a/src/components/home/FeaturedProducts.js
+++ b/src/components/home/FeaturedProducts.js
@@ -10,6 +10,7 @@ const FeaturedProducts = ({
   title,
   products,
   currencySymbol,
+  currencyRate,
   onPress,
 }) => {
   const theme = useContext(ThemeContext);
@@ -30,6 +31,7 @@ const FeaturedProducts = ({
           <FeaturedProductItem
             product={item}
             currencySymbol={currencySymbol}
+            currencyRate={currencyRate}
             onPress={onPress}
           />
         )}
@@ -44,6 +46,7 @@ FeaturedProducts.propTypes = {
   title: PropTypes.string,
   style: PropTypes.object,
   currencySymbol: PropTypes.string.isRequired,
+  currencyRate: PropTypes.number.isRequired,
 };
 
 FeaturedProducts.defaultProps = {

--- a/src/components/home/HomeScreen.js
+++ b/src/components/home/HomeScreen.js
@@ -61,6 +61,7 @@ class HomeScreen extends Component {
         title={this.props.featuredCategories[key].title}
         onPress={this.onProductPress}
         currencySymbol={this.props.currencySymbol}
+        currencyRate={this.props.currencyRate}
       />
     ));
   }
@@ -113,6 +114,7 @@ HomeScreen.propTypes = {
   featuredCategories: PropTypes.object,
   setCurrentProduct: PropTypes.func,
   currencySymbol: PropTypes.string.isRequired,
+  currencyRate: PropTypes.number.isRequired,
   refreshing: PropTypes.bool,
 };
 
@@ -123,10 +125,19 @@ HomeScreen.defaultProps = {
 
 const mapStateToProps = (state) => {
   const { refreshing } = state.home;
-  const { errorMessage, currency } = state.magento;
-  const { default_display_currency_symbol: currencySymbol } = currency;
+  const {
+    errorMessage,
+    currency: {
+      displayCurrencySymbol: currencySymbol,
+      displayCurrencyExchangeRate: currencyRate,
+    },
+  } = state.magento;
   return {
-    ...state.home, refreshing, errorMessage, currencySymbol,
+    ...state.home,
+    refreshing,
+    errorMessage,
+    currencySymbol,
+    currencyRate,
   };
 };
 

--- a/src/components/search/SearchScreen.js
+++ b/src/components/search/SearchScreen.js
@@ -85,6 +85,7 @@ class SearchScreen extends Component {
       gridColumnsValue={this.state.gridColumnsValue}
       performSort={this.performSort}
       currencySymbol={this.props.currencySymbol}
+      currencyRate={this.props.currencyRate}
     />
   );
 
@@ -144,11 +145,23 @@ const styles = {
 const mapStateToProps = ({ search, filters, magento }) => {
   const { sortOrder, priceFilter } = filters;
   const { products, totalCount, loadingMore } = search;
-  const { default_display_currency_symbol: currencySymbol } = magento.currency;
+  const {
+    currency: {
+      displayCurrencySymbol: currencySymbol,
+      displayCurrencyExchangeRate: currencyRate,
+    },
+  } = magento;
   const canLoadMoreContent = products.length < totalCount;
 
   return {
-    products, totalCount, canLoadMoreContent, loadingMore, sortOrder, priceFilter, currencySymbol,
+    products,
+    sortOrder,
+    totalCount,
+    loadingMore,
+    priceFilter,
+    currencyRate,
+    currencySymbol,
+    canLoadMoreContent,
   };
 };
 

--- a/src/config/magento-sample.js
+++ b/src/config/magento-sample.js
@@ -1,3 +1,13 @@
+/**
+ * Magento Settings for the app,
+ * Follow instructions: https://github.com/troublediehard/magento-react-native/wiki/Setup
+ *
+ * url                     : Base url of the magento website
+ * home_cms_block_id       : Block id which conatin json data,
+ *                           which will be shown in Home screen
+ * access_token            : Token to access magento API, without it
+ *                           app won't work
+ */
 export const magentoOptions = {
   url: 'http://mage2.local/',
   home_cms_block_id: '19',
@@ -7,3 +17,22 @@ export const magentoOptions = {
     },
   },
 };
+
+/**
+ * Magento 2 REST API doesn't return currency symbol,
+ * so manually specify all currency symbol(that your store support)
+ * along side their currency code.
+ */
+export const currencySymbols = Object.freeze({
+  USD: '$',
+  EUR: '€',
+  AUD: 'A$',
+  GBP: '£',
+  CAD: 'CA$',
+  CNY: 'CN¥',
+  JPY: '¥',
+  SEK: 'SEK',
+  CHF: 'CHF',
+  INR: '₹',
+  KWD: 'د.ك',
+});

--- a/src/helper/price.js
+++ b/src/helper/price.js
@@ -1,3 +1,5 @@
+import { currencySymbols } from '../config/magento';
+
 export function finalPrice(data, price) {
   let specialPrice = price;
   const result = data.filter(item => item.attribute_code === 'special_price');
@@ -7,3 +9,12 @@ export function finalPrice(data, price) {
   }
   return specialPrice;
 }
+
+export const priceSignByCode = (code) => {
+  const sign = currencySymbols[code];
+  if (sign) {
+    return sign;
+  }
+  // If no currency symbol specified for currency code, return currency code
+  return code;
+};

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -103,7 +103,8 @@
     "noPaymentMethod": "Payment methods not found",
     "noShippingMethod": "Shipping methods not found for selected address",
     "placeOrderButton": "Place Order",
-    "orderSuccessMessage": "Order placed successfully"
+    "orderSuccessMessage": "Order placed successfully",
+    "youWillBeCharged": "You will be charged"
   },
   "search": {
     "title": "Search",

--- a/src/reducers/MagentoReducer.js
+++ b/src/reducers/MagentoReducer.js
@@ -8,7 +8,16 @@ const INITIAL_STATE = {
   magento: null,
   storeConfig: null,
   countries: null,
-  currency: {},
+  currency: {
+    default_display_currency_code: '',
+    default_display_currency_symbol: '',
+    /**
+     * Below three keys will be used in the APP
+     */
+    displayCurrencyCode: '',
+    displayCurrencySymbol: '',
+    displayCurrencyExchangeRate: 1,
+  },
 };
 
 export default (state = INITIAL_STATE, action) => {
@@ -28,15 +37,27 @@ export default (state = INITIAL_STATE, action) => {
       }
       return state;
     }
-    case MAGENTO_GET_CURRENCY:
-      const currency = action.payload;
-      if (!currency.base_currency_symbol) {
-        currency.base_currency_symbol = currency.base_currency_code;
-      }
-      if (!currency.default_display_currency_symbol) {
-        currency.default_display_currency_symbol = currency.default_display_currency_code;
-      }
-      return { ...state, errorMessage: null, currency };
+    case MAGENTO_GET_CURRENCY: {
+      const {
+        currencyData,
+        displayCurrency: {
+          code,
+          symbol,
+          rate
+        }
+      } = action.payload;
+      return {
+        ...state,
+        errorMessage: null,
+        currency: {
+          ...state.currency,
+          ...currencyData,
+          displayCurrencyCode: code,
+          displayCurrencySymbol: symbol,
+          displayCurrencyExchangeRate: rate,
+        }
+      };
+    }
     case MAGENTO_GET_COUNTRIES: {
       return { ...state, countries: action.payload };
     }

--- a/storybook/stories/Price.stories.js
+++ b/storybook/stories/Price.stories.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react-native';
+import { Price } from '../../src/components/common';
+import { ThemeProvider, theme } from '../../src/theme';
+
+storiesOf('Price', module)
+  .addDecorator(getStory => (
+    <ThemeProvider theme={theme}>{getStory()}</ThemeProvider>
+  ))
+  .add('with basePrice', () => (
+    <Price
+      basePrice={300}
+      currencySymbol="$"
+      currencyRate={1}
+    />
+  ))
+  .add('with discountPrice', () => (
+    <Price
+      basePrice={300}
+      discountPrice={200}
+      currencySymbol="$"
+      currencyRate={1}
+    />
+  ))
+  .add('with discountPrice = basePrice', () => (
+    <Price
+      basePrice={300}
+      discountPrice={300}
+      currencySymbol="$"
+      currencyRate={1}
+    />
+  ));

--- a/storybook/storyLoader.js
+++ b/storybook/storyLoader.js
@@ -8,13 +8,15 @@ function loadStories() {
 	require('./stories/Input.stories');
 	require('./stories/Spinner.stories');
 	require('./stories/Text.stories');
+	require('./stories/Price.stories');
 }
 
 const stories = [
-	'../src/components/common/Button/Button.stories',
-	'../src/components/common/Input/Input.stories',
-	'../src/components/common/Spinner/Spinner.stories',
-	'../src/components/common/Text/Text.stories'
+	'./stories/Button.stories',
+	'./stories/Input.stories',
+	'./stories/Spinner.stories',
+	'./stories/Text.stories',
+	'./stories/Price.stories',
 ];
 
 module.exports = {


### PR DESCRIPTION
**What does this implement/fix? Explain your changes.**
- New `Price` component to render price
- If `display` currency is different then `base` currency, then this PR multiplies base price with exchange rate and show currency currency symbol.
- In `Order` related screen, `order_currency_code` is used to determine price and currency symbol, instead of `display` currency

**Does this close any currently open issues?**
close #98

**Any other comments?**
- [ ] TODO: Show currency picker to change currency in the app

**Where has this been tested?**
---------------------------
 - Magento Version: [2.1.0]
 - Device: [Android Emulator Nexus 5X]
 - OS: [PIE 8.0]
 - Version [28]
