### PR TITLE
feat: Add drop drown to change display currency

### DIFF
--- a/src/actions/CustomerAuthActions.js
+++ b/src/actions/CustomerAuthActions.js
@@ -1,4 +1,4 @@
-import { AsyncStorage } from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
 import { magento } from '../magento';
 import {
   MAGENTO_PASSWORD_RESET_LOADING,

--- a/src/actions/RestActions.js
+++ b/src/actions/RestActions.js
@@ -1,4 +1,4 @@
-import { AsyncStorage } from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
 import _ from 'lodash';
 import { magento } from '../magento';
 import { magentoOptions } from '../config/magento';
@@ -102,7 +102,7 @@ async function getCurrencyToBeDisplayed(currencyData) {
 
   if ('available_currency_codes' in currencyData && currencyData.available_currency_codes.length > 0) {
     const previousSelectedCurrencyCode = await AsyncStorage.getItem('currency_code');
-    if (previousSelectedCurrencyCode && previousSelectedCurrencyCode !== code && previousSelectedCurrencyCode in currencyData.available_currency_codes) {
+    if (previousSelectedCurrencyCode && previousSelectedCurrencyCode !== code && currencyData.available_currency_codes.includes(previousSelectedCurrencyCode)) {
       code = previousSelectedCurrencyCode;
       symbol = priceSignByCode(code);
     }

--- a/src/actions/UIActions.js
+++ b/src/actions/UIActions.js
@@ -10,6 +10,7 @@ import {
   UI_ACCOUNT_CUSTOMER_DATA_UPDATE,
   UI_ACCOUNT_CUSTOMER_DATA_LOADING,
   UI_PRODUCT_UPDATE_CUSTOM_OPTIONS,
+  UI_CHANGE_CURRENCY,
 } from './types';
 
 export const updateProductQtyInput = qty => ({
@@ -65,4 +66,13 @@ export const updateAccountAddressUI = (key, value) => ({
 export const accountAddressNextLoading = loading => ({
   type: UI_ACCOUNT_CUSTOMER_DATA_LOADING,
   payload: loading,
+});
+
+export const changeCurrency = (currencyCode, currencySymbol, currencyRate) => ({
+  type: UI_CHANGE_CURRENCY,
+  payload: {
+    currencyCode,
+    currencySymbol,
+    currencyRate,
+  },
 });

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -63,6 +63,7 @@ export const UI_ACCOUNT_CUSTOMER_DATA_UPDATE = 'ui_account_customer_data_update'
 export const UI_ACCOUNT_CUSTOMER_DATA_LOADING = 'ui_account_customer_data_loading';
 export const RESET_ACCOUNT_ADDRESS_UI = 'reset_account_address_ui';
 export const MAGENTO_ADD_ACCOUNT_ADDRESS_ERROR = 'magento_add_account_address_error';
+export const UI_CHANGE_CURRENCY = 'Change_Display_Currency';
 
 export const UI_CHECKOUT_ACTIVE_SECTION = 'ui_checkout_active_section';
 

--- a/src/components/account/AuthLoading.js
+++ b/src/components/account/AuthLoading.js
@@ -3,8 +3,8 @@ import {
   View,
   StatusBar,
   StyleSheet,
-  AsyncStorage,
 } from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
 import { Spinner } from '../common';
 import {
   NAVIGATION_ACCOUNT_STACK_PATH,

--- a/src/components/common/ModalSelect.js
+++ b/src/components/common/ModalSelect.js
@@ -15,7 +15,7 @@ const ModalSelect = ({
   const [value, setValue] = useState('');
 
   const _onChange = (option) => {
-    setValue(`${label} : ${option.label}`);
+    setValue(attribute === 'CurrencyCode' ? option.label : `${label} : ${option.label}`);
 
     if (onChange) {
       onChange(attribute, option.key);

--- a/src/components/home/CurrencyPicker.js
+++ b/src/components/home/CurrencyPicker.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import AsyncStorage from '@react-native-community/async-storage';
+import { connect } from 'react-redux';
+import { ModalSelect } from '../common';
+import { priceSignByCode, currencyExchangeRateByCode } from '../../helper/price';
+import { changeCurrency } from '../../actions';
+
+const CurrencyPicker = ({
+  currencies,
+  exchangeRates,
+  selectedCurrencyCode,
+  changeCurrency: _changeCurrency,
+}) => {
+  const data = currencies.map(value => ({
+    label: value,
+    key: value,
+  }));
+
+  const onChange = (atrribute, itemValue) => {
+    _changeCurrency(
+      itemValue,
+      priceSignByCode(itemValue),
+      currencyExchangeRateByCode(itemValue, exchangeRates),
+    );
+    AsyncStorage.setItem('currency_code', itemValue);
+  };
+
+  return (
+    <ModalSelect
+      disabled={data.length === 0}
+      label={selectedCurrencyCode}
+      attribute="CurrencyCode"
+      data={data}
+      onChange={onChange}
+      style={styles.currencyContainer}
+    />
+  );
+};
+
+const styles = {
+  currencyContainer: {
+    width: 50,
+    marginEnd: 10,
+  },
+};
+
+CurrencyPicker.propTypes = {
+  currencies: PropTypes.arrayOf(PropTypes.string),
+  exchangeRates: PropTypes.arrayOf(PropTypes.shape({
+    currency_to: PropTypes.string.isRequired,
+    rate: PropTypes.number.isRequired,
+  })),
+  selectedCurrencyCode: PropTypes.string,
+  changeCurrency: PropTypes.func.isRequired,
+};
+
+CurrencyPicker.defaultProps = {
+  currencies: [],
+  exchangeRates: [],
+  selectedCurrencyCode: '',
+};
+
+const mapStatetoProps = ({ magento }) => {
+  const {
+    currency: {
+      available_currency_codes: currencies,
+      exchange_rates: exchangeRates,
+      displayCurrencyCode: selectedCurrencyCode,
+    },
+  } = magento;
+  return {
+    currencies,
+    exchangeRates,
+    selectedCurrencyCode,
+  };
+};
+
+export default connect(mapStatetoProps, { changeCurrency })(CurrencyPicker);

--- a/src/components/home/HomeScreen.js
+++ b/src/components/home/HomeScreen.js
@@ -11,6 +11,7 @@ import {
 } from '../../navigation/routes';
 import { getHomeData, setCurrentProduct } from '../../actions';
 import HomeSlider from './HomeSlider';
+import CurrencyPicker from './CurrencyPicker';
 import FeaturedProducts from './FeaturedProducts';
 import NavigationService from '../../navigation/NavigationService';
 import { ThemeContext } from '../../theme';
@@ -27,6 +28,7 @@ class HomeScreen extends Component {
         <Item title="menu" iconName="menu" onPress={navigation.getParam('toggleDrawer')} />
       </MaterialHeaderButtons>
     ),
+    headerRight: <CurrencyPicker />,
   });
 
   componentDidMount() {

--- a/src/helper/app.js
+++ b/src/helper/app.js
@@ -1,4 +1,4 @@
-import { AsyncStorage } from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
 import { magento } from '../magento';
 import { initMagento, getCart, setCurrentCustomer } from '../actions';
 import { logError } from './logger';

--- a/src/helper/price.js
+++ b/src/helper/price.js
@@ -18,3 +18,11 @@ export const priceSignByCode = (code) => {
   // If no currency symbol specified for currency code, return currency code
   return code;
 };
+
+export const currencyExchangeRateByCode = (code, exchangeRates) => {
+  const result = exchangeRates.find(exchangeRate => exchangeRate.currency_to === code);
+  if (result) {
+    return result.rate;
+  }
+  return 1;
+};

--- a/src/reducers/MagentoReducer.js
+++ b/src/reducers/MagentoReducer.js
@@ -1,6 +1,11 @@
 import { REHYDRATE } from 'redux-persist/es/constants';
 import {
-  MAGENTO_GET_COUNTRIES, MAGENTO_INIT, MAGENTO_INIT_ERROR, MAGENTO_STORE_CONFIG, MAGENTO_GET_CURRENCY,
+  MAGENTO_INIT,
+  MAGENTO_INIT_ERROR,
+  UI_CHANGE_CURRENCY,
+  MAGENTO_STORE_CONFIG,
+  MAGENTO_GET_CURRENCY,
+  MAGENTO_GET_COUNTRIES,
 } from '../actions/types';
 import { magento } from '../magento';
 
@@ -55,9 +60,19 @@ export default (state = INITIAL_STATE, action) => {
           displayCurrencyCode: code,
           displayCurrencySymbol: symbol,
           displayCurrencyExchangeRate: rate,
-        }
+        },
       };
     }
+    case UI_CHANGE_CURRENCY:
+      return {
+        ...state,
+        currency: {
+          ...state.currency,
+          displayCurrencyCode: action.payload.currencyCode,
+          displayCurrencySymbol: action.payload.currencySymbol,
+          displayCurrencyExchangeRate: action.payload.currencyRate,
+        },
+      };
     case MAGENTO_GET_COUNTRIES: {
       return { ...state, countries: action.payload };
     }


### PR DESCRIPTION
**What does this implement/fix? Explain your changes.**
Show a picker in Home Page to change currency,

**Does this close any currently open issues?**
close #98

**Screenshots**
![Screenshot_1574419116](https://user-images.githubusercontent.com/13250741/69419439-775fef80-0d42-11ea-97af-2ca73deac0e3.png)
![Screenshot_1574419112](https://user-images.githubusercontent.com/13250741/69419440-78911c80-0d42-11ea-9ede-6925074f78a5.png)
![Screenshot_1574419123](https://user-images.githubusercontent.com/13250741/69419444-79c24980-0d42-11ea-8938-9e0a2247dcb1.png)

**Any other comments?**
- Please test the functionality in ios
- Haven't handle the case when only one currency is available from backend, picker will not hide

**Where has this been tested?**
---------------------------
 - Magento Version: [2.1.0]
 - Device: [Android Emulator Nexus 5X]
 - OS: [9.0 (Pie) - API 28]
