### PR TITLE
Feature/related item list

### DIFF
--- a/src/actions/ProductActions.js
+++ b/src/actions/ProductActions.js
@@ -1,0 +1,37 @@
+import { magento } from '../magento';
+import { updateConfigurableProductsPrices } from './RestActions';
+import {
+  MAGENTO_RELATED_PRODUCTS_LOADING,
+  MAGENTO_RELATED_PRODUCTS_CONF_PRODUCT,
+  MAGENTO_RELATED_PRODUCTS_SUCCESS,
+  MAGENTO_RELATED_PRODUCTS_ERROR,
+} from './types';
+
+/**
+ * Get product from a category
+ */
+export const getRelatedProduct = (categoryIds, sku) => async (dispatch) => {
+  try {
+    dispatch({ type: MAGENTO_RELATED_PRODUCTS_LOADING, payload: true });
+    const result = await magento.admin.getProductsWithAttribute(
+      'category_id',
+      categoryIds,
+      11,
+      0,
+      false,
+      false,
+      'in',
+    );
+    result.items = result.items.filter(product => product.sku !== sku);
+    updateConfigurableProductsPrices(
+      result.items,
+      dispatch,
+      MAGENTO_RELATED_PRODUCTS_CONF_PRODUCT,
+    );
+    if (result && result.items) {
+      dispatch({ type: MAGENTO_RELATED_PRODUCTS_SUCCESS, payload: result.items });
+    }
+  } catch (error) {
+    dispatch({ type: MAGENTO_RELATED_PRODUCTS_ERROR, payload: { errorMessage: error.message } });
+  }
+};

--- a/src/actions/RestActions.js
+++ b/src/actions/RestActions.js
@@ -268,20 +268,20 @@ export const getSearchProducts = (searchInput, offset, sortOrder, filter) => asy
   }
 };
 
-export const getCustomOptions = sku => async (dispatch) => {
+export const getCustomOptions = (sku, id) => async (dispatch) => {
   try {
     const data = await magento.admin.getProductOptions(sku);
-    dispatch({ type: MAGENTO_GET_CUSTOM_OPTIONS, payload: data });
+    dispatch({ type: MAGENTO_GET_CUSTOM_OPTIONS, payload: { data, id } });
   } catch (e) {
     logError(e);
   }
 };
 
-export const getConfigurableProductOptions = sku => (dispatch) => {
+export const getConfigurableProductOptions = (sku, id) => (dispatch) => {
   magento.admin
     .getConfigurableProductOptions(sku)
     .then((data) => {
-      dispatch({ type: MAGENTO_GET_CONF_OPTIONS, payload: data });
+      dispatch({ type: MAGENTO_GET_CONF_OPTIONS, payload: { data, id } });
       data.forEach((option) => {
         magento.admin
           .getAttributeByCode(option.attribute_id)
@@ -289,6 +289,7 @@ export const getConfigurableProductOptions = sku => (dispatch) => {
             dispatch({
               type: MAGENTO_PRODUCT_ATTRIBUTE_OPTIONS,
               payload: {
+                productId: id,
                 attributeId: option.attribute_id,
                 options: attributeOptions.options,
                 attributeCode: attributeOptions.attribute_code,
@@ -318,20 +319,20 @@ const updateConfigurableProductPrice = async (
   dispatch,
   type = MAGENTO_UPDATE_CONF_PRODUCT,
 ) => {
-  const { sku } = product;
+  const { sku, id } = product;
   try {
     const data = await magento.admin.getConfigurableChildren(sku);
-    dispatch({ type, payload: { sku, children: data } });
+    dispatch({ type, payload: { sku, children: data, id } });
   } catch (e) {
     logError(e);
   }
 };
 
-export const getProductMedia = ({ sku }) => (dispatch) => {
+export const getProductMedia = ({ sku, id }) => (dispatch) => {
   magento.admin
     .getProductMedia(sku)
     .then((media) => {
-      dispatch({ type: MAGENTO_GET_PRODUCT_MEDIA, payload: { sku, media } });
+      dispatch({ type: MAGENTO_GET_PRODUCT_MEDIA, payload: { sku, media, id } });
     })
     .catch((error) => {
       logError(error);

--- a/src/actions/RestActions.js
+++ b/src/actions/RestActions.js
@@ -305,7 +305,7 @@ export const getConfigurableProductOptions = sku => (dispatch) => {
     });
 };
 
-const updateConfigurableProductsPrices = (products, dispatch, type) => {
+export const updateConfigurableProductsPrices = (products, dispatch, type) => {
   products.forEach((product) => {
     if (product.type_id === 'configurable') {
       updateConfigurableProductPrice(product, dispatch, type);

--- a/src/actions/UIActions.js
+++ b/src/actions/UIActions.js
@@ -14,19 +14,19 @@ import {
   UI_PRODUCT_LIST_TYPE_GRID,
 } from './types';
 
-export const updateProductQtyInput = qty => ({
+export const updateProductQtyInput = (qty, id) => ({
   type: UI_PRODUCT_QTY_INPUT,
-  payload: qty,
+  payload: { qty, id },
 });
 
-export const uiProductUpdate = selectedOptions => ({
+export const uiProductUpdate = (selectedOptions, id) => ({
   type: UI_PRODUCT_UPDATE_OPTIONS,
-  payload: selectedOptions,
+  payload: { selectedOptions, id },
 });
 
-export const uiProductCustomOptionUpdate = selectedOptions => ({
+export const uiProductCustomOptionUpdate = (selectedOptions, id) => ({
   type: UI_PRODUCT_UPDATE_CUSTOM_OPTIONS,
-  payload: selectedOptions,
+  payload: { selectedOptions, id },
 });
 
 export const checkoutSelectedShippingChanged = shipping => ({

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -2,3 +2,4 @@ export * from './RestActions';
 export * from './UIActions';
 export * from './CustomerAuthActions';
 export * from './CartActions';
+export * from './ProductActions';

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -90,3 +90,11 @@ export const UI_PRODUCT_LIST_TYPE_GRID = 'ui_product_list_type_grid';
 export const MAGENTO_COUPON_LOADING = 'MAGENTO_COUPON_LOADING';
 export const MAGENTO_COUPON_ERROR = 'MAGENTO_COUPON_ERROR';
 export const MAGENTO_CHECKOUT_TOTALS = 'MAGENTO_CHECKOUT_TOTALS';
+
+/**
+ * Action Names for "Related Product" in Product Screen
+ */
+export const MAGENTO_RELATED_PRODUCTS_LOADING = 'magento_related_products_loading';
+export const MAGENTO_RELATED_PRODUCTS_SUCCESS = 'magento_related_products_success';
+export const MAGENTO_RELATED_PRODUCTS_ERROR = 'magento_related_products_error';
+export const MAGENTO_RELATED_PRODUCTS_CONF_PRODUCT = 'magento_related_products_conf_product_update';

--- a/src/components/catalog/Category.js
+++ b/src/components/catalog/Category.js
@@ -44,9 +44,10 @@ const Category = ({
   }, []);
 
   const onRowPress = (product) => {
-    _setCurrentProduct({ product });
+    _setCurrentProduct({ product });_setCurrentProduct
     NavigationService.navigate(NAVIGATION_HOME_PRODUCT_PATH, {
       title: product.name,
+      product: product,
     });
   };
 

--- a/src/components/catalog/Product.js
+++ b/src/components/catalog/Product.js
@@ -14,6 +14,7 @@ import {
   uiProductUpdate,
   uiProductCustomOptionUpdate,
   getCustomOptions,
+  setCurrentProduct,
   getRelatedProduct,
 } from '../../actions';
 import { Spinner, ModalSelect, Button, Text, Input, Price } from '../common';
@@ -23,6 +24,9 @@ import { logError } from '../../helper/logger';
 import { ThemeContext } from '../../theme';
 import { translate } from '../../i18n';
 import { finalPrice } from '../../helper/price';
+import {
+  NAVIGATION_HOME_PRODUCT_PATH,
+} from '../../navigation/routes';
 import FeaturedProducts from '../home/FeaturedProducts';
 
 class Product extends Component {
@@ -38,11 +42,13 @@ class Product extends Component {
     uiProductUpdateOptions: PropTypes.func,
     addToCartLoading: PropTypes.func,
     addToCart: PropTypes.func,
+    setCurrentProduct: PropTypes.func,
     getRelatedProduct: PropTypes.func,
     updateProductQtyInput: PropTypes.func,
     relatedProducts: PropTypes.arrayOf(PropTypes.object),
     relatedProductsLoading: PropTypes.bool,
     relatedProductsError: PropTypes.string,
+    current: PropTypes.object,
   };
 
   static defaultProps = {
@@ -59,17 +65,27 @@ class Product extends Component {
     showRelatedProduct: true,
   };
 
+  constructor(props) {
+    super(props);
+
+    const { navigation } = props;
+    const params = navigation && navigation.state.params ? navigation.state.params : {};
+    const { product } = params;
+    this.state.product = product;
+  }
+
   componentDidMount() {
-    const { product, medias } = this.props;
+    const { product } = this.state;
+    const { medias } = this.props.current[product.id] ? this.props.current[product.id] : {};
 
     if (product.type_id === 'configurable') {
-      this.props.getConfigurableProductOptions(product.sku);
+      this.props.getConfigurableProductOptions(product.sku, product.id);
+      this.props.getCustomOptions(product.sku, product.id);
     }
 
-    this.props.getCustomOptions(product.sku);
 
     if (!medias || !medias[product.sku]) {
-      this.props.getProductMedia({ sku: product.sku });
+      this.props.getProductMedia({ sku: product.sku, id: product.id });
     }
 
     const categoryIds = getProductCustomAttributeValue(product, 'category_ids');
@@ -81,11 +97,26 @@ class Product extends Component {
     }
   }
 
+  componentDidUpdate(props) {
+    if (
+      props.current
+      && props.current[this.state.product.id]
+      && props.current[this.state.product.id].product
+      && props.current[this.state.product.id].product.price !== this.state.product.price
+    ) {
+      this.setState({
+        product: props.current[this.state.product.id].product,
+      });
+    }
+  }
+
   onPressAddToCart = () => {
     console.log('onPressAddToCart');
+    const { product } = this.state;
+    const { cart, customer } = this.props;
     const {
-      cart, product, qty, selectedOptions, customer, selectedCustomOptions,
-    } = this.props;
+      qtyInput: qty, selectedOptions, selectedCustomOptions,
+    } = this.props.current[product.id];
     const options = [];
     Object.keys(selectedOptions).forEach((key) => {
       console.log(selectedOptions[key]);
@@ -146,22 +177,24 @@ class Product extends Component {
 
   // TODO: refactor action name
   optionSelect = (attributeId, optionValue) => {
-    const { selectedOptions } = this.props;
+    const { product } = this.state;
+    const { selectedOptions } = this.props.current[product.id];
     const updatedOptions = { ...selectedOptions, [attributeId]: optionValue };
-    this.props.uiProductUpdateOptions(updatedOptions);
+    this.props.uiProductUpdateOptions(updatedOptions, product.id);
 
     this.updateSelectedProduct(updatedOptions);
   }
 
   customOptionSelect = (optionId, optionValue) => {
-    const { selectedCustomOptions } = this.props;
+    const { product } = this.state;
+    const { selectedCustomOptions } = this.props.current[product.id];
     const updatedCustomOptions = { ...selectedCustomOptions, [optionId]: optionValue };
-    this.props.uiProductCustomOptionUpdate(updatedCustomOptions);
+    this.props.uiProductCustomOptionUpdate(updatedCustomOptions, product.id);
   };
 
   renderDescription() {
     const theme = this.context;
-    const { product } = this.props;
+    const { product } = this.state;
     const attribute = getProductCustomAttribute(product, 'description');
     if (attribute) {
       let description = attribute.value.replace(/<\/?[^>]+(>|$)/g, '');
@@ -175,13 +208,12 @@ class Product extends Component {
     }
   }
 
-  onProductPress() {
-    alert('Not implemented yet!');
-    // this.props.setCurrentProduct({ product });
-    // this.props.navigation.push(NAVIGATION_HOME_PRODUCT_PATH, {
-    //   title: product.name,
-    //   product: product,
-    // });
+  onProductPress(product) {
+    this.props.setCurrentProduct({ product });
+    this.props.navigation.push(NAVIGATION_HOME_PRODUCT_PATH, {
+      title: product.name,
+      product: product,
+    });
   }
 
   renderRelatedProduct() {
@@ -193,15 +225,17 @@ class Product extends Component {
         products={{ items: products }}
         title={translate('product.relatedProductsTitle')}
         titleStyle={styles.relatedProductTitle}
-        onPress={this.onProductPress}
+        onPress={this.onProductPress.bind(this)}
         currencySymbol={this.props.currencySymbol}
+        currencyRate={this.props.currencyRate}
       />
     );
   }
 
   renderCustomOptions = () => {
     const theme = this.context;
-    const { customOptions } = this.props;
+    const { product } = this.state;
+    const { customOptions } = this.props.current[product.id];
     if (customOptions) {
       return customOptions.map((option) => {
         const data = option.values.map(value => ({
@@ -227,9 +261,10 @@ class Product extends Component {
 
   renderOptions = () => {
     const theme = this.context;
+    const { product } = this.state;
     const {
-      options, attributes, product, selectedOptions,
-    } = this.props;
+      options, attributes, selectedOptions,
+    } = this.props.current[product.id];
 
     if (Array.isArray(options) && product.children) {
       const prevOptions = [];
@@ -316,15 +351,16 @@ class Product extends Component {
   }
 
   updateSelectedProduct = (selectedOptions) => {
-    const { product } = this.props;
+    const { product } = this.state;
+    const { attributes, options } = this.props.current[product.id];
     const selectedKeys = Object.keys(selectedOptions);
 
     if (!product.children || !selectedKeys.length) return;
 
-    if (selectedKeys.length === this.props.options?.length) {
+    if (selectedKeys.length === options.length) {
       const searchOption = {};
       selectedKeys.forEach((attribute_id) => {
-        const code = this.props.attributes[attribute_id].attributeCode;
+        const code = attributes[attribute_id].attributeCode;
         searchOption[code] = selectedOptions[attribute_id];
       });
 
@@ -337,10 +373,10 @@ class Product extends Component {
       });
 
       if (selectedProduct) {
-        const { medias } = this.props;
+        const { medias } = this.props.current[this.state.product.id];
         this.setState({ selectedProduct });
         if (!medias || !medias[selectedProduct.sku]) {
-          this.props.getProductMedia({ sku: selectedProduct.sku });
+          this.props.getProductMedia({ sku: selectedProduct.sku, id: product.id });
         }
       }
     }
@@ -361,8 +397,8 @@ class Product extends Component {
     return (
       <Price
         style={styles.priceContainer}
-        basePrice={this.props.product.price}
-        discountPrice={finalPrice(this.props.product.custom_attributes, this.props.product.price)}
+        basePrice={this.state.product.price}
+        discountPrice={finalPrice(this.state.product.custom_attributes, this.state.product.price)}
         currencySymbol={this.props.currencySymbol}
         currencyRate={this.props.currencyRate}
       />
@@ -370,8 +406,8 @@ class Product extends Component {
   }
 
   renderProductMedia = () => {
-    const { medias, product } = this.props;
-    const { selectedProduct } = this.state;
+    const { selectedProduct, product } = this.state;
+    const { medias } = this.props.current[product.id];
     if (!medias) {
       return (
         <ProductMedia media={null} />
@@ -389,15 +425,16 @@ class Product extends Component {
 
   render() {
     const theme = this.context;
-    const { showRelatedProduct } = this.state;
+    const { showRelatedProduct, product } = this.state;
     const { relatedProductsError } = this.props;
+    const current = this.props.current[product.id];
     console.log('Product screen render');
     return (
       <ScrollView
         style={styles.container(theme)}
       >
         {this.renderProductMedia()}
-        <Text type="heading" bold style={styles.textStyle(theme)}>{this.props.product.name}</Text>
+        <Text type="heading" bold style={styles.textStyle(theme)}>{product.name}</Text>
         {this.renderPrice()}
         <Text bold style={styles.textStyle(theme)}>{translate('common.quantity')}</Text>
         <Input
@@ -405,8 +442,8 @@ class Product extends Component {
           inputStyle={{ textAlign: 'center' }}
           autoCorrect={false}
           keyboardType="numeric"
-          value={`${this.props.qty}`}
-          onChangeText={qty => this.props.updateProductQtyInput(qty)}
+          value={`${current.qtyInput}`}
+          onChangeText={qty => this.props.updateProductQtyInput(qty, product.id)}
         />
         {this.renderOptions()}
         {this.renderCustomOptions()}
@@ -462,11 +499,7 @@ const styles = StyleSheet.create({
 });
 
 const mapStateToProps = (state) => {
-  const { product, options, medias, customOptions } = state.product.current;
   const {
-    attributes,
-    selectedOptions,
-    selectedCustomOptions,
     relatedProducts: {
       items: relatedProducts,
       loading: relatedProductsLoading,
@@ -480,26 +513,18 @@ const mapStateToProps = (state) => {
       displayCurrencyExchangeRate: currencyRate,
     },
   } = state.magento;
+
   const { cart, account } = state;
-  console.log('Product Component');
-  console.log(state.product);
-  console.log(cart);
+
   return {
     cart,
-    medias,
-    product,
-    options,
-    attributes,
     currencyRate,
     relatedProducts,
     relatedProductsLoading,
     relatedProductsError,
-    customOptions,
     currencySymbol,
-    selectedOptions,
-    selectedCustomOptions,
     customer: account.customer,
-    qty: state.product.qtyInput,
+    current: state.product.current,
   };
 };
 
@@ -511,6 +536,7 @@ export default connect(mapStateToProps, {
   updateProductQtyInput,
   getCustomOptions,
   uiProductCustomOptionUpdate,
+  setCurrentProduct,
   getRelatedProduct,
   uiProductUpdateOptions: uiProductUpdate,
 })(Product);

--- a/src/components/catalog/ProductCustomOptions.js
+++ b/src/components/catalog/ProductCustomOptions.js
@@ -1,0 +1,46 @@
+/**
+ * @flow
+ * Created by Dima Portenko on 14.05.2020
+ */
+import React, { useContext } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { ModalSelect } from '../common';
+import { ThemeContext } from '../../theme';
+
+export const ProductCustomOptions = ({ currentProduct }) => {
+  const theme = useContext(ThemeContext);
+  const { customOptions } = currentProduct;
+
+  if (!customOptions) {
+    return <View />;
+  }
+
+  return customOptions.map((option) => {
+    const data = option.values.map(value => ({
+      label: value.title,
+      key: value.option_type_id,
+    }));
+
+    return (
+      <ModalSelect
+        style={styles.modalStyle(theme)}
+        disabled={data.length === 0}
+        key={option.option_id}
+        label={option.title}
+        attribute={option.option_id}
+        value={option.option_id}
+        data={data}
+        onChange={this.customOptionSelect}
+      />
+    );
+  });
+};
+
+const styles = StyleSheet.create({
+  modalStyle: theme => ({
+    alignSelf: 'center',
+    width: theme.dimens.WINDOW_WIDTH * 0.9,
+    marginBottom: theme.spacing.large,
+  }),
+});
+

--- a/src/components/catalog/ProductMediaContainer.js
+++ b/src/components/catalog/ProductMediaContainer.js
@@ -1,0 +1,36 @@
+/**
+ * @flow
+ * Created by Dima Portenko on 14.05.2020
+ */
+import React, { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import ProductMedia from './ProductMedia';
+import { getProductMedia } from '../../actions';
+
+export const ProductMediaContainer = ({ product, selectedProductSku }) => {
+  const current = useSelector(({ product }) => (product.current));
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const { medias } = current[product.id] || {};
+
+    if (!medias || !medias[product.sku]) {
+      dispatch(getProductMedia({ sku: product.sku, id: product.id }));
+    }
+  }, []);
+
+  const { medias } = current[product.id];
+  if (!medias) {
+    return (
+      <ProductMedia media={null} />
+    );
+  }
+  if (selectedProductSku && medias[selectedProductSku]) {
+    return (
+      <ProductMedia media={medias[selectedProductSku]} />
+    );
+  }
+  return (
+    <ProductMedia media={medias[product.sku]} />
+  );
+};

--- a/src/components/catalog/ProductOptions.js
+++ b/src/components/catalog/ProductOptions.js
@@ -1,0 +1,137 @@
+/**
+ * @flow
+ * Created by Dima Portenko on 14.05.2020
+ */
+import React, { useContext } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { useDispatch } from 'react-redux';
+import { getProductCustomAttribute } from '../../helper/product';
+import { ModalSelect } from '../common';
+import { ThemeContext } from '../../theme';
+import { getProductMedia, uiProductUpdate } from '../../actions';
+import _ from 'lodash';
+
+export const ProductOptions = ({ currentProduct, product, setSelectedProduct }) => {
+  const theme = useContext(ThemeContext);
+  const dispatch = useDispatch();
+  const { options, attributes, selectedOptions } = currentProduct;
+
+  if (!(Array.isArray(options) && product.children)) {
+    return <View />;
+  }
+
+  const optionSelect = (attributeId, optionValue) => {
+    const { selectedOptions } = currentProduct;
+    const updatedOptions = { ...selectedOptions, [attributeId]: optionValue };
+    dispatch(uiProductUpdate(updatedOptions, product.id));
+
+    updateSelectedProduct(updatedOptions);
+  };
+
+  const updateSelectedProduct = (selectedOptions) => {
+    const { attributes, options } = currentProduct;
+    const selectedKeys = Object.keys(selectedOptions);
+
+    if (!product.children || !selectedKeys.length) {return;}
+
+    if (selectedKeys.length === options.length) {
+      const searchOption = {};
+      selectedKeys.forEach((attribute_id) => {
+        const code = attributes[attribute_id].attributeCode;
+        searchOption[code] = selectedOptions[attribute_id];
+      });
+
+      const _selectedProduct = product.children.find((child) => {
+        const found = _.every(searchOption, (value, code) => {
+          const childOption = getProductCustomAttribute(child, code);
+          return Number(childOption.value) === Number(value);
+        });
+        return found;
+      });
+
+      if (_selectedProduct) {
+        const { medias } = currentProduct;
+        setSelectedProduct(_selectedProduct);
+        if (!medias || !medias[_selectedProduct.sku]) {
+          dispatch(getProductMedia({ sku: _selectedProduct.sku, id: product.id }));
+        }
+      }
+    }
+  };
+
+  const prevOptions = [];
+  let first = true;
+  return options.map((option) => {
+    if (!attributes[option.attribute_id]) {
+      return <View key={option.id} />;
+    }
+
+    let data = option.values.map((value) => {
+      let optionLabel = value.value_index;
+
+      if (attributes && attributes[option.attribute_id]) {
+        const findedValue = attributes[option.attribute_id].options.find(optionData => Number(optionData.value) === Number(value.value_index));
+        if (findedValue) {
+          optionLabel = findedValue.label;
+        }
+      }
+
+      if (first) {
+        return {
+          label: optionLabel,
+          key: value.value_index,
+        };
+      }
+
+      const match = product.children.find((child) => {
+        let found = 0;
+        prevOptions.every((prevOption) => {
+          const { attributeCode } = attributes[prevOption.attribute_id];
+          const currentAttributeCode = attributes[option.attribute_id].attributeCode;
+          const childOption = getProductCustomAttribute(child, attributeCode);
+          const currentOption = getProductCustomAttribute(child, currentAttributeCode);
+          const selectedValue = selectedOptions[prevOption.attribute_id];
+          if (Number(childOption.value) === Number(selectedValue)
+            && Number(currentOption.value) === Number(value.value_index)) {
+            found++;
+            return false;
+          }
+          return true;
+        });
+        return found === prevOptions.length;
+      });
+
+      if (match) {
+        return {
+          label: optionLabel,
+          key: value.value_index,
+        };
+      }
+      return false;
+    });
+    data = data.filter(object => object !== false);
+    first = false;
+    prevOptions.push(option);
+
+    return (
+      <ModalSelect
+        style={styles.modalStyle(theme)}
+        disabled={data.length === 0}
+        key={option.id}
+        label={option.label}
+        attribute={option.attribute_id}
+        value={option.id}
+        data={data}
+        onChange={optionSelect}
+      />
+    );
+  });
+};
+
+const styles = StyleSheet.create({
+  modalStyle: theme => ({
+    alignSelf: 'center',
+    width: theme.dimens.WINDOW_WIDTH * 0.9,
+    marginBottom: theme.spacing.large,
+  }),
+});

--- a/src/components/catalog/ProductScreen.js
+++ b/src/components/catalog/ProductScreen.js
@@ -19,7 +19,7 @@ import { ProductOptions } from './ProductOptions';
 import { ProductCustomOptions } from './ProductCustomOptions';
 import { useAddToCart } from '../../hooks/useAddToCart';
 import { useProductDescription } from '../../hooks/useProductDescription';
-import { RelatedProduct } from './RelatedProduct';
+import { RelatedProducts } from './RelatedProducts';
 
 export const ProductScreen = (props) => {
   const {
@@ -123,7 +123,12 @@ export const ProductScreen = (props) => {
       {renderAddToCartButton()}
       <Text style={styles.errorStyle(theme)}>{cart.errorMessage}</Text>
       <Text style={styles.descriptionStyle(theme)}>{description}</Text>
-      <RelatedProduct product={product} />
+      <RelatedProducts
+        product={product}
+        currencyRate={currencyRate}
+        currencySymbol={currencySymbol}
+        navigation={props.navigation}
+      />
     </ScrollView>
   );
 };

--- a/src/components/catalog/ProductScreen.js
+++ b/src/components/catalog/ProductScreen.js
@@ -25,9 +25,6 @@ export const ProductScreen = (props) => {
   const {
     cart,
     currencyRate,
-    relatedProducts,
-    relatedProductsLoading,
-    relatedProductsError,
     currencySymbol,
     customer,
     current,
@@ -177,14 +174,6 @@ const styles = StyleSheet.create({
 
 const mapStateToProps = (state) => {
   const {
-    relatedProducts: {
-      items: relatedProducts,
-      loading: relatedProductsLoading,
-      error: relatedProductsError,
-    }
-  } = state.product;
-
-  const {
     currency: {
       displayCurrencySymbol: currencySymbol,
       displayCurrencyExchangeRate: currencyRate,
@@ -196,9 +185,6 @@ const mapStateToProps = (state) => {
   return {
     cart,
     currencyRate,
-    relatedProducts,
-    relatedProductsLoading,
-    relatedProductsError,
     currencySymbol,
     customer: account.customer,
     current: state.product.current,

--- a/src/components/catalog/ProductScreen.js
+++ b/src/components/catalog/ProductScreen.js
@@ -1,0 +1,201 @@
+/**
+ * @flow
+ * Created by Dima Portenko on 14.05.2020
+ */
+import React, { useContext, useState, useEffect } from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { useSelector, useDispatch } from 'react-redux';
+import { Button, Input, Price, Spinner, Text } from '../common';
+import { translate } from '../../i18n';
+import { ThemeContext } from '../../theme';
+import {
+  getConfigurableProductOptions,
+  getCustomOptions,
+  updateProductQtyInput
+} from '../../actions';
+import { ProductMediaContainer } from './ProductMediaContainer';
+import { finalPrice } from '../../helper/price';
+import { ProductOptions } from './ProductOptions';
+import { ProductCustomOptions } from './ProductCustomOptions';
+import { useAddToCart } from '../../hooks/useAddToCart';
+import { useProductDescription } from '../../hooks/useProductDescription';
+import { RelatedProduct } from './RelatedProduct';
+
+export const ProductScreen = (props) => {
+  const {
+    cart,
+    currencyRate,
+    relatedProducts,
+    relatedProductsLoading,
+    relatedProductsError,
+    currencySymbol,
+    customer,
+    current,
+  } = useSelector(state => mapStateToProps(state));
+  const dispatch = useDispatch();
+  const params = props.navigation?.state?.params ? props.navigation?.state?.params : {};
+  const theme = useContext(ThemeContext);
+  const [product, setProduct] = useState(params.product);
+  const [currentProduct, setCurProduct] = useState(current[product.id]);
+  const [selectedProduct, setSelectedProduct] = useState(null);
+  const { onPressAddToCart } = useAddToCart({ product, cart, customer, currentProduct });
+  const { description } = useProductDescription({ product });
+
+  useEffect(() => {
+    if (product.type_id === 'configurable') {
+      dispatch(getConfigurableProductOptions(product.sku, product.id));
+      dispatch(getCustomOptions(product.sku, product.id));
+    }
+
+    // const categoryIds = getProductCustomAttributeValue(product, 'category_ids');
+    // if (categoryIds && categoryIds.length) {
+    //   this.props.getRelatedProduct(categoryIds, product.sku);
+    // } else {
+    //   // No category id present in custom_attributes
+    //   this.setState({ showRelatedProduct: false });
+  }, []);
+
+  useEffect(() => {
+    setCurProduct(current[product.id]);
+  }, [current])
+
+  const renderPrice = () => {
+    if (selectedProduct) {
+      return (
+        <Price
+          style={styles.priceContainer}
+          basePrice={selectedProduct.price}
+          currencySymbol={currencySymbol}
+          currencyRate={currencyRate}
+        />
+      );
+    }
+    return (
+      <Price
+        style={styles.priceContainer}
+        basePrice={product.price}
+        discountPrice={finalPrice(product.custom_attributes, product.price)}
+        currencySymbol={currencySymbol}
+        currencyRate={currencyRate}
+      />
+    );
+  };
+
+  const renderAddToCartButton = () => {
+    if (cart.addToCartLoading) {
+      return <Spinner />;
+    }
+    return (
+      <Button style={styles.buttonStyle(theme)} onPress={onPressAddToCart}>
+        {translate('product.addToCartButton')}
+      </Button>
+    );
+  };
+
+
+  return (
+    <ScrollView
+      style={styles.container(theme)}
+    >
+      <ProductMediaContainer
+        product={product}
+        selectedProductSku={selectedProduct?.sku}
+      />
+      <Text type="heading" bold style={styles.textStyle(theme)}>{product.name}</Text>
+      {renderPrice()}
+      <Text bold style={styles.textStyle(theme)}>{translate('common.quantity')}</Text>
+      <Input
+        containerStyle={styles.inputContainer(theme)}
+        inputStyle={{ textAlign: 'center' }}
+        autoCorrect={false}
+        keyboardType="numeric"
+        value={`${currentProduct.qtyInput}`}
+        onChangeText={qty => dispatch(updateProductQtyInput(qty, product.id))}
+      />
+      <ProductOptions
+        product={product}
+        currentProduct={currentProduct}
+        setSelectedProduct={setSelectedProduct}
+      />
+      <ProductCustomOptions
+        currentProduct={currentProduct}
+      />
+      {renderAddToCartButton()}
+      <Text style={styles.errorStyle(theme)}>{cart.errorMessage}</Text>
+      <Text style={styles.descriptionStyle(theme)}>{description}</Text>
+      <RelatedProduct product={product} />
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: theme => ({
+    flex: 1,
+    backgroundColor: theme.colors.background,
+  }),
+  textStyle: theme => ({
+    padding: theme.spacing.small,
+    textAlign: 'center',
+  }),
+  inputContainer: theme => ({
+    width: 40,
+    alignSelf: 'center',
+    marginBottom: theme.spacing.extraLarge,
+  }),
+  modalStyle: theme => ({
+    alignSelf: 'center',
+    width: theme.dimens.WINDOW_WIDTH * 0.9,
+    marginBottom: theme.spacing.large,
+  }),
+  buttonStyle: theme => ({
+    alignSelf: 'center',
+    marginTop: 10,
+    width: theme.dimens.WINDOW_WIDTH * 0.9,
+  }),
+  descriptionStyle: theme => ({
+    padding: theme.spacing.large,
+    lineHeight: 25,
+  }),
+  errorStyle: theme => ({
+    textAlign: 'center',
+    padding: theme.spacing.small,
+    color: theme.colors.error,
+  }),
+  priceContainer: {
+    alignSelf: 'center',
+  },
+  relatedProductTitle: {
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+});
+
+const mapStateToProps = (state) => {
+  const {
+    relatedProducts: {
+      items: relatedProducts,
+      loading: relatedProductsLoading,
+      error: relatedProductsError,
+    }
+  } = state.product;
+
+  const {
+    currency: {
+      displayCurrencySymbol: currencySymbol,
+      displayCurrencyExchangeRate: currencyRate,
+    },
+  } = state.magento;
+
+  const { cart, account } = state;
+
+  return {
+    cart,
+    currencyRate,
+    relatedProducts,
+    relatedProductsLoading,
+    relatedProductsError,
+    currencySymbol,
+    customer: account.customer,
+    current: state.product.current,
+  };
+};

--- a/src/components/catalog/RelatedProduct.js
+++ b/src/components/catalog/RelatedProduct.js
@@ -1,0 +1,47 @@
+/**
+ * @flow
+ * Created by Dima Portenko on 14.05.2020
+ */
+import React, { useContext } from 'react';
+import { StyleSheet, View } from 'react-native';
+import FeaturedProducts from '../home/FeaturedProducts';
+import { translate } from '../../i18n';
+import { ThemeContext } from '../../theme';
+import { NAVIGATION_HOME_PRODUCT_PATH } from '../../navigation/routes';
+import { useDispatch } from 'react-redux';
+import { setCurrentProduct } from '../../actions';
+import { useRelatedProducts } from '../../hooks/useRelatedProducts';
+
+export const RelatedProduct = ({ product, currencySymbol, currencyRate, navigation }) => {
+  const theme = useContext(ThemeContext);
+  const dispatch = useDispatch();
+
+  const { relatedProducts } = useRelatedProducts({ product });
+
+  const onProductPress = () => {
+    dispatch(setCurrentProduct({ product }));
+    navigation.push(NAVIGATION_HOME_PRODUCT_PATH, {
+      title: product.name,
+      product: product,
+    });
+  };
+
+  return (
+    <FeaturedProducts
+      style={{ marginBottom: theme.spacing.large }}
+      products={{ items: relatedProducts }}
+      title={translate('product.relatedProductsTitle')}
+      titleStyle={styles.relatedProductTitle}
+      onPress={onProductPress}
+      currencySymbol={currencySymbol}
+      currencyRate={currencyRate}
+    />
+  );
+};
+
+const styles = StyleSheet.create({
+  relatedProductTitle: {
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+});

--- a/src/components/catalog/RelatedProducts.js
+++ b/src/components/catalog/RelatedProducts.js
@@ -11,12 +11,20 @@ import { NAVIGATION_HOME_PRODUCT_PATH } from '../../navigation/routes';
 import { useDispatch } from 'react-redux';
 import { setCurrentProduct } from '../../actions';
 import { useRelatedProducts } from '../../hooks/useRelatedProducts';
+import { Spinner } from '../common';
 
 export const RelatedProducts = ({ product, currencySymbol, currencyRate, navigation }) => {
   const theme = useContext(ThemeContext);
   const dispatch = useDispatch();
+  const { relatedProducts, loading, error } = useRelatedProducts({ product });
 
-  const { relatedProducts } = useRelatedProducts({ product });
+  if (!relatedProducts?.length && !loading || error) {
+    return <View />;
+  }
+
+  if (loading) {
+    return <Spinner />;
+  }
 
   const onProductPress = (pressedProduct) => {
     dispatch(setCurrentProduct({ product: pressedProduct }));

--- a/src/components/catalog/RelatedProducts.js
+++ b/src/components/catalog/RelatedProducts.js
@@ -12,17 +12,17 @@ import { useDispatch } from 'react-redux';
 import { setCurrentProduct } from '../../actions';
 import { useRelatedProducts } from '../../hooks/useRelatedProducts';
 
-export const RelatedProduct = ({ product, currencySymbol, currencyRate, navigation }) => {
+export const RelatedProducts = ({ product, currencySymbol, currencyRate, navigation }) => {
   const theme = useContext(ThemeContext);
   const dispatch = useDispatch();
 
   const { relatedProducts } = useRelatedProducts({ product });
 
-  const onProductPress = () => {
-    dispatch(setCurrentProduct({ product }));
+  const onProductPress = (pressedProduct) => {
+    dispatch(setCurrentProduct({ product: pressedProduct }));
     navigation.push(NAVIGATION_HOME_PRODUCT_PATH, {
-      title: product.name,
-      product: product,
+      title: pressedProduct.name,
+      product: pressedProduct,
     });
   };
 

--- a/src/components/home/HomeScreen.js
+++ b/src/components/home/HomeScreen.js
@@ -47,6 +47,7 @@ class HomeScreen extends Component {
   onProductPress = (product) => {
     this.props.setCurrentProduct({ product });
     NavigationService.navigate(NAVIGATION_HOME_PRODUCT_PATH, {
+      product,
       title: product.name,
     });
   };

--- a/src/components/search/SearchScreen.js
+++ b/src/components/search/SearchScreen.js
@@ -35,6 +35,7 @@ class SearchScreen extends Component {
   onRowPress = (product) => {
     this.props.setCurrentProduct({ product });
     NavigationService.navigate(NAVIGATION_SEARCH_PRODUCT_PATH, {
+      product,
       title: product.name,
     });
   }

--- a/src/helper/product.js
+++ b/src/helper/product.js
@@ -11,6 +11,12 @@ export const getProductThumbnailFromAttribute = (product) => {
   return result;
 };
 
+export const getProductCustomAttributeValue = (product, key) => {
+  const attribute = getProductCustomAttribute(product, key);
+  const value = attribute ? attribute.value : attribute;
+  return value;
+}
+
 export const getProductCustomAttribute = (product, key) => {
   const attributes = product.custom_attributes.filter(attribute => attribute.attribute_code === key);
 

--- a/src/hooks/useAddToCart.js
+++ b/src/hooks/useAddToCart.js
@@ -1,0 +1,84 @@
+/**
+ * @flow
+ * Created by Dima Portenko on 14.05.2020
+ */
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import { addToCart, addToCartLoading } from '../actions';
+
+export const useAddToCart = (
+  {
+    product,
+    cart,
+    customer,
+    currentProduct,
+  }
+ ) => {
+  const dispatch = useDispatch();
+
+  const onPressAddToCart = () => {
+    const {
+      qtyInput: qty, selectedOptions, selectedCustomOptions,
+    } = currentProduct;
+    const options = [];
+    Object.keys(selectedOptions).forEach((key) => {
+      console.log(selectedOptions[key]);
+      options.push({
+        optionId: key,
+        optionValue: selectedOptions[key],
+        extensionAttributes: {},
+      });
+    });
+
+    const customOptions = [];
+    selectedCustomOptions && Object.keys(selectedCustomOptions).forEach((key) => {
+      console.log(selectedCustomOptions[key]);
+      customOptions.push({
+        optionId: key,
+        optionValue: selectedCustomOptions[key],
+        extensionAttributes: {},
+      });
+    });
+
+    let productOptions = {};
+    if (options.length) {
+      productOptions = {
+        productOption: {
+          extensionAttributes: {
+            configurableItemOptions: options,
+          },
+        },
+      };
+    }
+
+    if (productOptions.productOption && productOptions.productOption.extensionAttributes) {
+      productOptions.productOption.extensionAttributes.customOptions = customOptions;
+    } else {
+      productOptions = {
+        productOption: {
+          extensionAttributes: {
+            customOptions,
+          },
+        },
+      };
+    }
+
+    dispatch(addToCartLoading(true));
+    dispatch(addToCart({
+      cartId: cart.cartId,
+      item: {
+        cartItem: {
+          sku: product.sku,
+          qty,
+          quoteId: cart.cartId,
+          ...productOptions,
+        },
+      },
+      customer,
+    }));
+  };
+
+  return {
+    onPressAddToCart,
+  };
+};

--- a/src/hooks/useProductDescription.js
+++ b/src/hooks/useProductDescription.js
@@ -2,23 +2,30 @@
  * @flow
  * Created by Dima Portenko on 14.05.2020
  */
-import React, { useMemo } from 'react';
+import React, { useEffect, useState } from 'react';
 import { getProductCustomAttribute } from '../helper/product';
-import { logError } from '../helper/logger';
 
 export const useProductDescription = ({ product }) => {
-  const description = useMemo(() => {
+  const [description, setDescription] = useState('');
+
+  const decode = async (desc) => {
+    let _desc = desc;
+    try {
+      _desc = decodeURI(desc);
+    } catch (e) {
+
+    }
+    setDescription(_desc);
+  };
+
+  useEffect(() => {
     let desc = '';
     const attribute = getProductCustomAttribute(product, 'description');
     if (attribute) {
       desc = attribute.value.replace(/<\/?[^>]+(>|$)/g, '');
-      // try {
-      //   desc = decodeURI(description);
-      // } catch (e) {
-      //   logError(e);
-      // }
+      desc = desc.replace('&bull;', '\n•');
+      decode(desc);
     }
-    return desc;
   }, [product]);
 
   return {

--- a/src/hooks/useProductDescription.js
+++ b/src/hooks/useProductDescription.js
@@ -1,0 +1,27 @@
+/**
+ * @flow
+ * Created by Dima Portenko on 14.05.2020
+ */
+import React, { useMemo } from 'react';
+import { getProductCustomAttribute } from '../helper/product';
+import { logError } from '../helper/logger';
+
+export const useProductDescription = ({ product }) => {
+  const description = useMemo(() => {
+    let desc = '';
+    const attribute = getProductCustomAttribute(product, 'description');
+    if (attribute) {
+      desc = attribute.value.replace(/<\/?[^>]+(>|$)/g, '');
+      // try {
+      //   desc = decodeURI(description);
+      // } catch (e) {
+      //   logError(e);
+      // }
+    }
+    return desc;
+  }, [product]);
+
+  return {
+    description,
+  };
+};

--- a/src/hooks/useRelatedProducts.js
+++ b/src/hooks/useRelatedProducts.js
@@ -4,15 +4,60 @@
  */
 import React, { useEffect, useState } from 'react';
 import { magento } from '../magento';
+import { MAGENTO_UPDATE_CONF_PRODUCT } from '../actions/types';
+import { logError } from '../helper/logger';
+import { getPriceFromChildren } from '../helper/product';
+
+const getSearchCriteriaWithSkus = skus => ({
+  groups: [
+    [{
+        field: 'sku',
+        value: skus,
+        conditionType: 'in',
+    }],
+    [{
+      field: 'visibility',
+      value: '4',
+      conditionType: 'eq',
+    }],
+  ],
+});
+
+const updateConfigurableProductsPrices = (products) => {
+  return products.map((product) => {
+    if (product.type_id === 'configurable') {
+      return updateConfigurableProductPrice(product);
+    }
+    return product;
+  });
+};
+
+const updateConfigurableProductPrice = async (product) => {
+  try {
+    const data = await magento.admin.getConfigurableChildren(product.sku);
+    return {
+      ...product,
+      children: data,
+      price: getPriceFromChildren(data),
+    };
+  } catch (e) {
+    logError(e);
+  }
+};
 
 export const useRelatedProducts = ({ product }) => {
   const [relatedProducts, setRelatedProducts] = useState([]);
 
   const getRelatedProducts = async (product) => {
     try {
-      const result = await magento.admin.getLinkedProducts(product.sku, 'related');
-      console.warn('result', result);
+      const linksData = await magento.admin.getLinkedProducts(product.sku, 'related');
+      const skus = linksData.map(item => item.linked_product_sku);
+      const data = await magento.admin.getProductsBy(getSearchCriteriaWithSkus(skus));
+      const products = await Promise.all(updateConfigurableProductsPrices(data.items));
+
+      setRelatedProducts(products);
     } catch (e) {
+      // TODO: handle error
       console.warn('error', e);
     }
   };

--- a/src/hooks/useRelatedProducts.js
+++ b/src/hooks/useRelatedProducts.js
@@ -1,0 +1,25 @@
+/**
+ * @flow
+ * Created by Dima Portenko on 14.05.2020
+ */
+import React, { useEffect, useState } from 'react';
+import { magento } from '../magento';
+
+export const useRelatedProducts = ({ product }) => {
+  const [relatedProducts, setRelatedProducts] = useState([]);
+
+  const getRelatedProducts = async (product) => {
+    try {
+      const result = await magento.admin.getLinkedProducts(product.sku, 'related');
+      console.warn('result', result);
+    } catch (e) {
+      console.warn('error', e);
+    }
+  };
+
+  useEffect(() => {
+    getRelatedProducts(product);
+  }, [product]);
+
+  return { relatedProducts };
+};

--- a/src/hooks/useRelatedProducts.js
+++ b/src/hooks/useRelatedProducts.js
@@ -47,18 +47,23 @@ const updateConfigurableProductPrice = async (product) => {
 
 export const useRelatedProducts = ({ product }) => {
   const [relatedProducts, setRelatedProducts] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
 
   const getRelatedProducts = async (product) => {
     try {
+      setLoading(true);
+      setError(false);
       const linksData = await magento.admin.getLinkedProducts(product.sku, 'related');
       const skus = linksData.map(item => item.linked_product_sku);
       const data = await magento.admin.getProductsBy(getSearchCriteriaWithSkus(skus));
       const products = await Promise.all(updateConfigurableProductsPrices(data.items));
 
       setRelatedProducts(products);
-    } catch (e) {
-      // TODO: handle error
-      console.warn('error', e);
+      setLoading(false);
+    } catch (error) {
+      setError(error);
+      logError(error);
     }
   };
 
@@ -66,5 +71,5 @@ export const useRelatedProducts = ({ product }) => {
     getRelatedProducts(product);
   }, [product]);
 
-  return { relatedProducts };
+  return { relatedProducts, error, loading };
 };

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -92,7 +92,8 @@
     "removeItemDialogMessage": "Just double-checking you wanted to remove the item"
   },
   "product": {
-    "addToCartButton": "Add to Cart"
+    "addToCartButton": "Add to Cart",
+    "relatedProductsTitle":"You may also like"
   },
   "checkout": {
     "title": "Checkout",

--- a/src/magento/lib/admin/index.js
+++ b/src/magento/lib/admin/index.js
@@ -225,4 +225,6 @@ export default magento => ({
     };
     return magento.get(path, params, undefined, ADMIN_TYPE);
   },
+
+  getLinkedProducts: (sku, type) => magento.get(`/V1/products/${sku}/links/${type}`, undefined, undefined, ADMIN_TYPE),
 });

--- a/src/magento/lib/admin/index.js
+++ b/src/magento/lib/admin/index.js
@@ -1,4 +1,5 @@
 import { ADMIN_TYPE } from '../../types';
+import { getParamsFromSearchCriterias } from '../../utils/params';
 
 
 const getSortFieldName = (sortOrder) => {
@@ -182,6 +183,11 @@ export default magento => ({
     }
 
     return magento.admin.getProductsWithSearchCritaria(params);
+  },
+
+  getProductsBy: searchCriteria => {
+    const params = getParamsFromSearchCriterias(searchCriteria);
+    return magento.get('/V1/products', params, undefined, ADMIN_TYPE);
   },
 
   getProductsWithSearchCritaria: searchCriteria => magento.get('/V1/products', searchCriteria, undefined, ADMIN_TYPE),

--- a/src/magento/utils/params.js
+++ b/src/magento/utils/params.js
@@ -1,0 +1,27 @@
+export const getParamsFromSearchCriterias = (searchCriterias) => {
+  if (searchCriterias.groups) {
+    let params = {};
+    searchCriterias.groups.forEach((item, index) => {
+      params = { ...params, ...getParamsFromSearchCriteriaGroup(item, index) };
+    });
+    return params;
+  } else if (searchCriterias.length) {
+    return getParamsFromSearchCriteriaGroup(searchCriterias, 0);
+  } else {
+    return getParamsFromSearchCriteriaItem(searchCriterias);
+  }
+};
+
+const getParamsFromSearchCriteriaGroup = (group, groupNumber) => {
+  let params = {};
+  group.forEach((item, index) => {
+    params = { ...params, ...getParamsFromSearchCriteriaItem(item, groupNumber, index) };
+  });
+  return params;
+};
+
+const getParamsFromSearchCriteriaItem = (searchCriteria, filterGroups = 0, filters = 0) => ({
+  [`searchCriteria[filterGroups][${filterGroups}][filters][${filters}][field]`]: searchCriteria.field,
+  [`searchCriteria[filterGroups][${filterGroups}][filters][${filters}][value]`]: searchCriteria.value,
+  [`searchCriteria[filterGroups][${filterGroups}][filters][${filters}][condition_type]`]: searchCriteria.conditionType,
+});

--- a/src/navigation/Navigator.js
+++ b/src/navigation/Navigator.js
@@ -33,6 +33,7 @@ import CartBadge from '../components/cart/CartBadge';
 import * as routes from './routes';
 
 import { theme } from '../theme';
+import { ProductScreen } from '../components/catalog/ProductScreen';
 
 const defaultHeader = {
   headerStyle: {
@@ -50,7 +51,8 @@ const HomeStack = createStackNavigator(
   {
     [routes.NAVIGATION_HOME_SCREEN_PATH]: HomeScreen,
     [routes.NAVIGATION_CATEGORY_PATH]: Category,
-    [routes.NAVIGATION_HOME_PRODUCT_PATH]: Product,
+    // [routes.NAVIGATION_HOME_PRODUCT_PATH]: Product,
+    [routes.NAVIGATION_HOME_PRODUCT_PATH]: ProductScreen,
   },
   {
     initialRouteName: routes.NAVIGATION_HOME_SCREEN_PATH,


### PR DESCRIPTION
**What does this implement/fix? Explain your changes.**
This PR adds **Related Products** in Product Detail Screen. 

**Does this close any currently open issues?**
#129

**Any other comments?**
- **NOTE 1:** Functionality is not tested for Guest Cart
- **NOTE 2:** Functionality is not tested on iOS device
- **NOTE 3:** The way `relatedProducts` logic is currently setup in `ProductReducer` creates one problem. Suppose you open first Product, and from its related product you open second product, the new Product screen will come, and now it's related product will get load, but when you hit back, coming back to first product screen, the related products are shown of the second product, not its original related products.
**Solution:** Move `realtedProducts` logic into `current` in `productReducer`

**Where has this been tested?**
---------------------------
 - Magento Version: [2.3.1]
 - Device: [Android Emulator ]
 - OS: [9.0 (Pie) - API 28]
