### PR TITLE
Fix custom options not showing on product screen.

### DIFF
--- a/src/components/catalog/ProductCustomOptions.js
+++ b/src/components/catalog/ProductCustomOptions.js
@@ -3,16 +3,25 @@
  */
 import React, { useContext } from 'react';
 import { StyleSheet, View } from 'react-native';
+import { useDispatch } from 'react-redux';
 import { ModalSelect } from '../common';
+import { uiProductCustomOptionUpdate } from '../../actions';
 import { ThemeContext } from '../../theme';
 
-export const ProductCustomOptions = ({ currentProduct }) => {
+export const ProductCustomOptions = ({ currentProduct, product }) => {
   const theme = useContext(ThemeContext);
+  const dispatch = useDispatch();
   const { customOptions } = currentProduct;
 
   if (!customOptions) {
     return <View />;
   }
+
+  const customOptionSelect = (optionId, optionValue) => {
+    const { selectedCustomOptions } = currentProduct;
+    const updatedCustomOptions = { ...selectedCustomOptions, [optionId]: optionValue };
+    dispatch(uiProductCustomOptionUpdate(updatedCustomOptions, product.id));
+  };
 
   return customOptions.map((option) => {
     const data = option.values.map(value => ({
@@ -29,7 +38,7 @@ export const ProductCustomOptions = ({ currentProduct }) => {
         attribute={option.option_id}
         value={option.option_id}
         data={data}
-        onChange={this.customOptionSelect}
+        onChange={customOptionSelect}
       />
     );
   });
@@ -42,4 +51,3 @@ const styles = StyleSheet.create({
     marginBottom: theme.spacing.large,
   }),
 });
-

--- a/src/components/catalog/ProductScreen.js
+++ b/src/components/catalog/ProductScreen.js
@@ -43,8 +43,8 @@ export const ProductScreen = (props) => {
   useEffect(() => {
     if (product.type_id === 'configurable') {
       dispatch(getConfigurableProductOptions(product.sku, product.id));
-      dispatch(getCustomOptions(product.sku, product.id));
     }
+    dispatch(getCustomOptions(product.sku, product.id)); /*The custom options are available on all product types. */
   }, []); // eslint-disable-line
 
   useEffect(() => {
@@ -110,6 +110,7 @@ export const ProductScreen = (props) => {
         setSelectedProduct={setSelectedProduct}
       />
       <ProductCustomOptions
+        product={product}
         currentProduct={currentProduct}
       />
       {renderAddToCartButton()}


### PR DESCRIPTION
**What does this implement/fix? Explain your changes.**
This will fix problem with product custom options are not showing on product screen.


**Screenshots**
If applicable, add screenshots of end result.
![Screenshot_1597599035](https://user-images.githubusercontent.com/367271/90340228-e263fb80-e020-11ea-928c-13ab1800d5c2.png)


**Where has this been tested?**
---------------------------
 - Magento Version: 2.3.5
 - Device: Android Simulator
 - OS: Android
 - Version 29
